### PR TITLE
fix(test-config): Change browser-name case, add browser list

### DIFF
--- a/testacular/testacular-unit.js
+++ b/testacular/testacular-unit.js
@@ -41,10 +41,10 @@ autoWatch = false;
 /**
  * The list of browsers to launch to test on. This is empty by default, so you
  * will need to manually open your browser to http://localhot:9018/ for the 
- * tests to work. You can also just add the executable name of your browser(s)
- * here, e.g. 'firefox', 'chrome', 'chromium'.
+ * tests to work. Currently available browser names:
+ * Chrome, ChromeCanary, Firefox, Opera, Safari, PhantomJS
  */
 browsers = [
-  'firefox'
+  'Firefox'
 ];
 


### PR DESCRIPTION
The lowercase browser names break in Mac OS.  They're supposed to start uppercase I think, that's the way Testacular supplies it in the generated config.  I also added the list of possible browsers.
