### PR TITLE
feat(build): Add grunt-ngmin for annotation

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,6 +11,7 @@ module.exports = function ( grunt ) {
   grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-contrib-uglify');
+  grunt.loadNpmTasks('grunt-ngmin');
 
   /**
    * The `build` directory contains our custom Grunt tasks for using testacular
@@ -132,6 +133,18 @@ module.exports = function ( grunt ) {
     },
 
     /**
+     * Use ng-min to annotate the sources before minifying
+     */
+    ngmin: {
+      dist: {
+        expand: true,
+        cwd: '<%= distdir %>/assets/',
+        src: ['<%= pkg.name %>.js'],
+        dest: '<%= distdir %>/tmp'
+      }
+    },
+
+    /**
      * Minify the sources!
      */
     uglify: {
@@ -140,7 +153,7 @@ module.exports = function ( grunt ) {
       },
       dist: {
         files: {
-          '<%= distdir %>/assets/<%= pkg.name %>.min.js': [ '<%= distdir %>/assets/<%= pkg.name %>.js' ]
+          '<%= distdir %>/assets/<%= pkg.name %>.min.js': [ '<%= distdir %>/tmp/<%= pkg.name %>.js' ]
         }
       }
     },
@@ -262,7 +275,7 @@ module.exports = function ( grunt ) {
         files: [ 
           '<%= src.js %>'
         ],
-        tasks: [ 'jshint:src', 'test:unit', 'concat:dist', 'uglify:dist' ]
+        tasks: [ 'jshint:src', 'test:unit', 'concat:dist', 'ngmin:dist', 'uglify:dist' ]
       },
 
       /**
@@ -292,7 +305,7 @@ module.exports = function ( grunt ) {
           '<%= src.atpl %>', 
           '<%= src.ctpl %>'
         ],
-        tasks: [ 'html2js', 'concat:dist', 'uglify:dist' ]
+        tasks: [ 'html2js', 'concat:dist', 'ngmin:dist', 'uglify:dist' ]
       },
 
       /**
@@ -331,7 +344,7 @@ module.exports = function ( grunt ) {
    * The default task is to build.
    */
   grunt.registerTask( 'default', [ 'build' ] );
-  grunt.registerTask( 'build', ['clean', 'html2js', 'jshint', 'test', 'concat', 'uglify', 'recess', 'index', 'copy'] );
+  grunt.registerTask( 'build', ['clean', 'html2js', 'jshint', 'test', 'concat', 'ngmin', 'uglify', 'recess', 'index', 'copy'] );
 
   /**
    * A task to build the project, without some of the slower processes. This is

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "grunt-contrib-jshint": "~0.1.1",
     "grunt-contrib-concat": "~0.1.2",
     "grunt-contrib-watch": "~0.2.0",
-    "grunt-contrib-uglify": "~0.1.1"
+    "grunt-contrib-uglify": "~0.1.1",
+    "grunt-ngmin": "0.0.1"
   }
 }

--- a/src/app/about/about.js
+++ b/src/app/about/about.js
@@ -4,14 +4,14 @@ angular.module( 'ngBoilerplate.about', [
   'titleService'
 ])
 
-.config([ '$routeProvider', function config( $routeProvider ) {
+.config(function config( $routeProvider ) {
   $routeProvider.when( '/about', {
     controller: 'AboutCtrl',
     templateUrl: 'about/about.tpl.html'
   });
-}])
+})
 
-.controller( 'AboutCtrl', [ '$scope', 'titleService', function AboutCtrl( $scope, titleService ) {
+.controller( 'AboutCtrl', function AboutCtrl( $scope, titleService ) {
   titleService.setTitle( 'What is It?' );
   
   // This is simple a demo for UI Boostrap.
@@ -20,6 +20,6 @@ angular.module( 'ngBoilerplate.about', [
     "And another choice for you.",
     "but wait! A third!"
   ];
-}])
+})
 
 ;

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -10,12 +10,12 @@ angular.module( 'ngBoilerplate', [
   $routeProvider.otherwise({ redirectTo: '/home' });
 })
 
-.run([ 'titleService', function run ( titleService ) {
+.run(function run ( titleService ) {
   titleService.setSuffix( ' | ngBoilerplate' );
-}])
+})
 
-.controller( 'AppCtrl', [ '$scope', '$location', function AppCtrl ( $scope, $location ) {
-}])
+.controller( 'AppCtrl', function AppCtrl ( $scope, $location ) {
+})
 
 ;
 

--- a/src/app/home/home.js
+++ b/src/app/home/home.js
@@ -22,19 +22,19 @@ angular.module( 'ngBoilerplate.home', [
  * will handle ensuring they are all available at run-time, but splitting it
  * this way makes each module more "self-contained".
  */
-.config([ '$routeProvider', function config( $routeProvider ) {
+.config(function config( $routeProvider ) {
   $routeProvider.when( '/home', {
     controller: 'HomeCtrl',
     templateUrl: 'home/home.tpl.html'
   });
-}])
+})
 
 /**
  * And of course we define a controller for our route.
  */
-.controller( 'HomeCtrl', [ '$scope', 'titleService', function HomeController( $scope, titleService ) {
+.controller( 'HomeCtrl', function HomeController( $scope, titleService ) {
   titleService.setTitle( 'Home' );
-}])
+})
 
 ;
 

--- a/src/components/activeIfCurrent/activeIfCurrentDirective.js
+++ b/src/components/activeIfCurrent/activeIfCurrentDirective.js
@@ -1,6 +1,6 @@
 angular.module( 'activeIfCurrent', [])
 
-.directive( 'activeIfCurrent', [ '$location', function( $location ) {
+.directive( 'activeIfCurrent', function( $location ) {
   return {
     scope: true,
     link: function( scope, element, attrs ) {
@@ -19,5 +19,7 @@ angular.module( 'activeIfCurrent', [])
       scope.$on( '$locationChangeSuccess', check );
     }
   };
-}]);
+})
+
+;
 

--- a/src/components/plusOne/plusOne.js
+++ b/src/components/plusOne/plusOne.js
@@ -1,6 +1,6 @@
 angular.module( 'plusOne', [] )
 
-.directive( 'plusOne', [ function() {
+.directive( 'plusOne', function() {
   return {
     link: function( scope, element, attrs ) {
       gapi.plusone.render( element[0], {
@@ -9,7 +9,7 @@ angular.module( 'plusOne', [] )
       });
     }
   };
-}])
+})
 
 ;
 

--- a/src/components/titleService/titleService.js
+++ b/src/components/titleService/titleService.js
@@ -1,6 +1,6 @@
 angular.module( 'titleService', [])
 
-.factory( 'titleService', [ '$document', function ( $document ) {
+.factory( 'titleService', function ( $document ) {
   var suffix, title;
   
   var titleService = {
@@ -25,5 +25,7 @@ angular.module( 'titleService', [])
   };
 
   return titleService;
-}]);
+})
+
+;
 


### PR DESCRIPTION
Unfortunately, grunt-ngmin is still in an early state right now and can't handle the fancy way ng-boilerplate does module declaration (with the `.config` `.controller` etc functions called on a seperate line from the module declaration), so it doesn't work yet.  Still, it could stay in a branch for now until ngmin matures.  Or we can be more verbose with declaration of things (it does work if we put `angular.module('module')` before every call).
