### PR TITLE
Fixes #37. Use a different port to run Karma. All credits to @helmi03.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -263,6 +263,7 @@ module.exports = function ( grunt ) {
         configFile: 'karma/karma-unit.js'
       },
       unit: {
+        runnerPort: 9101,
         background: true
       },
       continuous: {


### PR DESCRIPTION
Tested on:
- MacOS 10.7.5 (Karma 0.8.5, NodeJS 0.10.4)
- Ubuntu 12.04 (Karma 0.8.5, NodeJS 0.10.10)
