### PR TITLE
Added Jade support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -161,7 +161,7 @@ module.exports = function ( grunt ) {
           '<%= vendor_files.js %>', 
           'module.suffix' 
         ],
-        dest: '<%= compile_dir %>/assets/<%= pkg.name %>.js'
+        dest: '<%= compile_dir %>/assets/<%= pkg.name %>-<%= pkg.version %>.js'
       }
     },
 
@@ -224,7 +224,7 @@ module.exports = function ( grunt ) {
     recess: {
       build: {
         src: [ '<%= app_files.less %>' ],
-        dest: '<%= build_dir %>/assets/<%= pkg.name %>.css',
+        dest: '<%= build_dir %>/assets/<%= pkg.name %>-<%= pkg.version %>.css',
         options: {
           compile: true,
           compress: false,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,6 +18,7 @@ module.exports = function ( grunt ) {
   grunt.loadNpmTasks('grunt-karma');
   grunt.loadNpmTasks('grunt-ngmin');
   grunt.loadNpmTasks('grunt-html2js');
+  grunt.loadNpmTasks('grunt-contrib-jade');
 
   /**
    * Load in our build configuration file.
@@ -158,10 +159,29 @@ module.exports = function ( grunt ) {
           '<%= build_dir %>/src/**/*.js', 
           '<%= html2js.app.dest %>', 
           '<%= html2js.common.dest %>', 
+          '<%= html2js.jade_app.dest %>', 
+          '<%= html2js.jade_common.dest %>', 
           '<%= vendor_files.js %>', 
           'module.suffix' 
         ],
         dest: '<%= compile_dir %>/assets/<%= pkg.name %>-<%= pkg.version %>.js'
+      }
+    },
+    
+    /**
+     * `grunt-contrib-jade` compiles jade files to html and puts them in build_dir
+     */
+    jade: {
+      compile: {
+        files: [
+          {
+            src: [ '<%= app_files.jade %>' ],
+            cwd: '.',
+            dest: '<%= build_dir %>',
+            expand: true,
+            ext: '.html'
+          }
+        ]
       }
     },
 
@@ -321,7 +341,30 @@ module.exports = function ( grunt ) {
         },
         src: [ '<%= app_files.ctpl %>' ],
         dest: '<%= build_dir %>/templates-common.js'
+      },
+      
+      /**
+       * These are the jade files from `src/app`.
+       */
+      jade_app: {
+        options: {
+          base: 'build/src/app'
+        },
+        src: [ 'build/src/app/**/*.html' ],
+        dest: '<%= build_dir %>/templates-jade-app.js'
+      },
+      
+      /**
+       * These are the jade files from `src/common`.
+       */
+      jade_common: {
+        options: {
+          base: 'build/src/common'
+        },
+        src: [ 'build/src/common/**/*.html' ],
+        dest: '<%= build_dir %>/templates-jade-common.js'
       }
+      
     },
 
     /**
@@ -359,6 +402,8 @@ module.exports = function ( grunt ) {
           '<%= build_dir %>/src/**/*.js',
           '<%= html2js.common.dest %>',
           '<%= html2js.app.dest %>',
+          '<%= html2js.jade_app.dest %>', 
+          '<%= html2js.jade_common.dest %>', 
           '<%= vendor_files.css %>',
           '<%= recess.build.dest %>'
         ]
@@ -390,6 +435,8 @@ module.exports = function ( grunt ) {
           '<%= vendor_files.js %>',
           '<%= html2js.app.dest %>',
           '<%= html2js.common.dest %>',
+          '<%= html2js.jade_app.dest %>', 
+          '<%= html2js.jade_common.dest %>', 
           'vendor/angular-mocks/angular-mocks.js'
         ]
       }
@@ -479,6 +526,13 @@ module.exports = function ( grunt ) {
         ],
         tasks: [ 'html2js' ]
       },
+      
+      jadesrc: {
+        files: [
+          '<%= app_files.jade %>'
+        ],
+        tasks: [ 'jade', 'html2js' ]
+      },
 
       /**
        * When the CSS files change, we need to compile and minify them.
@@ -539,7 +593,7 @@ module.exports = function ( grunt ) {
    * The `build` task gets your app ready to run for development and testing.
    */
   grunt.registerTask( 'build', [
-    'clean', 'html2js', 'jshint', 'coffeelint', 'coffee','recess:build',
+    'clean', 'jshint', 'coffeelint', 'coffee', 'jade', 'html2js', 'recess:build',
     'copy:build_assets', 'copy:build_appjs', 'copy:build_vendorjs',
     'index:build', 'karmaconfig', 'karma:continuous' 
   ]);

--- a/build.config.js
+++ b/build.config.js
@@ -30,7 +30,9 @@ module.exports = {
     ctpl: [ 'src/common/**/*.tpl.html' ],
 
     html: [ 'src/index.html' ],
-    less: 'src/less/main.less'
+    less: 'src/less/main.less',
+		
+    jade: [ 'src/**/*.jade']
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "grunt-contrib-coffee": "~0.7.0",
     "grunt-coffeelint": "0.0.6",
     "grunt-conventional-changelog": "~0.1.1",
-    "grunt-bump": "0.0.6"
+    "grunt-bump": "0.0.6",
+    "grunt-contrib-jade": "~0.7.0"
   }
 }

--- a/src/app/about/sample.jade
+++ b/src/app/about/sample.jade
@@ -1,0 +1,4 @@
+h1 Welcolme to Jade
+p
+  | Text can be included in a number of
+  | different ways.

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -1,6 +1,8 @@
 angular.module( 'ngBoilerplate', [
   'templates-app',
   'templates-common',
+  'templates-jade_app',
+  'templates-jade_common',
   'ngBoilerplate.home',
   'ngBoilerplate.about',
   'ui.state',


### PR DESCRIPTION
All Files defined in app_files.jade will compile to build_dir as html file. html2js will then run on those html files to generate
1. templates-jade-app.js &
2. templates-jade-common.js

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ngbp/ngbp/63)

<!-- Reviewable:end -->
