### PR TITLE
feat(e2e): Added E2E testing

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -121,7 +121,20 @@ module.exports = function ( grunt ) {
       build_vendorjs: {
         files: [
           {
-            src: [ '<%= vendor_files.js %>' ],
+            src: [
+              '<%= vendor_files.js %>',
+              '<%= vendor_files.dev %>'
+            ],
+            dest: '<%= build_dir %>/',
+            cwd: '.',
+            expand: true
+          }
+        ]
+      },
+      build_fixturejs: {
+        files: [
+          {
+            src: [ '<%= app_files.jsfixture %>' ],
             dest: '<%= build_dir %>/',
             cwd: '.',
             expand: true
@@ -155,7 +168,8 @@ module.exports = function ( grunt ) {
         src: [ 
           '<%= vendor_files.js %>', 
           'module.prefix', 
-          '<%= build_dir %>/src/**/*.js', 
+          '<%= build_dir %>/src/**/*.js',
+          '!<%= build_dir %>/src/**/*.fixture.js',
           '<%= html2js.app.dest %>', 
           '<%= html2js.common.dest %>', 
           '<%= vendor_files.js %>', 
@@ -173,15 +187,22 @@ module.exports = function ( grunt ) {
      * it in the final build, but we don't want to include our specs there.
      */
     coffee: {
+      options: {
+        bare: true
+      },
       source: {
-        options: {
-          bare: true
-        },
         expand: true,
         cwd: '.',
         src: [ '<%= app_files.coffee %>' ],
         dest: '<%= build_dir %>',
         ext: '.js'
+      },
+      fixture: {
+        expand: true,
+        cwd: '.',
+        src: [ '<%= app_files.coffeefixture %>' ],
+        dest: '<%= build_dir %>',
+        ext: '.fixture.js'
       }
     },
 
@@ -261,6 +282,12 @@ module.exports = function ( grunt ) {
       test: [
         '<%= app_files.jsunit %>'
       ],
+      fixture: [
+        '<%= app_files.jsfixture %>'
+      ],
+      scenario: [
+        '<%= app_files.jsscenario %>'
+      ],
       gruntfile: [
         'Gruntfile.js'
       ],
@@ -290,6 +317,16 @@ module.exports = function ( grunt ) {
       test: {
         files: {
           src: [ '<%= app_files.coffeeunit %>' ]
+        }
+      },
+      fixture: {
+        files: {
+          src: [ '<%= app_files.coffeefixture %>' ]
+        }
+      },
+      scenario: {
+        files: {
+          src: [ '<%= app_files.coffeescenario %>' ]
         }
       }
     },
@@ -337,6 +374,11 @@ module.exports = function ( grunt ) {
       },
       continuous: {
         singleRun: true
+      },
+      e2e: {
+        options: {
+          configFile: '<%= build_dir %>/karma-e2e.js'
+        }
       }
     },
 
@@ -357,10 +399,13 @@ module.exports = function ( grunt ) {
         src: [
           '<%= vendor_files.js %>',
           '<%= build_dir %>/src/**/*.js',
+          '!<%= build_dir %>/src/**/*.fixture.js',
           '<%= html2js.common.dest %>',
           '<%= html2js.app.dest %>',
           '<%= vendor_files.css %>',
-          '<%= recess.build.dest %>'
+          '<%= recess.build.dest %>',
+          '<%= vendor_files.dev %>',
+          '<%= build_dir %>/src/**/*.fixture.js'
         ]
       },
 
@@ -392,7 +437,9 @@ module.exports = function ( grunt ) {
           '<%= html2js.common.dest %>',
           'vendor/angular-mocks/angular-mocks.js'
         ]
-      }
+      },
+
+      e2e: {}
     },
 
     /**
@@ -505,6 +552,7 @@ module.exports = function ( grunt ) {
       /**
        * When a CoffeeScript unit test file changes, we only want to lint it and
        * run the unit tests. We don't want to do any live reloading.
+       * Karma will compile the CoffeeScript for us.
        */
       coffeeunit: {
         files: [
@@ -514,6 +562,48 @@ module.exports = function ( grunt ) {
         options: {
           livereload: false
         }
+      },
+
+      /**
+       * When a JavaScript data fixture file changes, we want to lint it and then
+       * copy it to the build folder.
+       */
+      jsfixture: {
+        files: [
+          '<%= app_files.jsfixture %>'
+        ],
+        tasks: [ 'jshint:fixture', 'copy:build_fixturejs' ]
+      },
+
+      /**
+       * When a CoffeeScript data fixture file changes, we want to lint it and then
+       * copy it to the build folder.
+       */
+      coffeefixture: {
+        files: [
+          '<%= app_files.coffeefixture %>'
+        ],
+        tasks: [ 'coffeelint:fixture', 'coffee:fixture', 'copy:build_fixturejs' ]
+      },
+
+      /**
+       * When a JavaScript e2e test file changes we just lint it.
+       */
+      jsscenario: {
+        files: [
+          '<%= app_files.jsscenario %>'
+        ],
+        tasks: [ 'jshint:scenario' ]
+      },
+
+      /**
+       * When a CoffeeScript e2e test file changes we just lint it.
+       */
+      coffeescenario: {
+        files: [
+          '<%= app_files.coffeescenario %>'
+        ],
+        tasks: [ 'coffeelint:scenario' ]
       }
     }
   };
@@ -539,9 +629,9 @@ module.exports = function ( grunt ) {
    * The `build` task gets your app ready to run for development and testing.
    */
   grunt.registerTask( 'build', [
-    'clean', 'html2js', 'jshint', 'coffeelint', 'coffee','recess:build',
-    'copy:build_assets', 'copy:build_appjs', 'copy:build_vendorjs',
-    'index:build', 'karmaconfig', 'karma:continuous' 
+    'clean', 'html2js', 'jshint', 'coffeelint', 'coffee', 'recess:build',
+    'copy:build_assets', 'copy:build_appjs', 'copy:build_vendorjs', 'copy:build_fixturejs',
+    'index:build', 'karmaconfig', 'karma:continuous', 'karma:e2e'
   ]);
 
   /**
@@ -584,6 +674,7 @@ module.exports = function ( grunt ) {
     var cssFiles = filterForCSS( this.filesSrc ).map( function ( file ) {
       return file.replace( dirRE, '' );
     });
+    var dev = this.target === 'build';
 
     grunt.file.copy('src/index.html', this.data.dir + '/index.html', { 
       process: function ( contents, path ) {
@@ -591,7 +682,8 @@ module.exports = function ( grunt ) {
           data: {
             scripts: jsFiles,
             styles: cssFiles,
-            version: grunt.config( 'pkg.version' )
+            version: grunt.config( 'pkg.version' ),
+            dev: dev
           }
         });
       }
@@ -605,8 +697,8 @@ module.exports = function ( grunt ) {
    */
   grunt.registerMultiTask( 'karmaconfig', 'Process karma config templates', function () {
     var jsFiles = filterForJS( this.filesSrc );
-    
-    grunt.file.copy( 'karma/karma-unit.tpl.js', grunt.config( 'build_dir' ) + '/karma-unit.js', { 
+
+    grunt.file.copy( 'karma/karma-' + this.target + '.tpl.js', grunt.config( 'build_dir' ) + '/karma-' + this.target + '.js', {
       process: function ( contents, path ) {
         return grunt.template.process( contents, {
           data: {

--- a/README.md
+++ b/README.md
@@ -260,8 +260,9 @@ changes:
   `src/less/main.less` file is linted and copied into
   `build/assets/ng-boilerplate.css`.
 * `delta:jssrc` - When any JavaScript file within `src/` that does not end in
-  `.spec.js` changes, all JavaScript sources are linted, all unit tests are run,
-  and the all source files are re-copied to `build/src`.
+  `.spec.js`, `.fixture.js` or `.scenario.js` changes, all JavaScript sources
+  are linted, all unit tests are run, and the all source files are re-copied
+  to `build/src`.
 * `delta:coffeesrc` - When any `*.coffee` file in `src/` that doesn't match
   `*.spec.coffee` changes, the Coffee scripts are compiled independently into
   `build/src` in a structure mirroring where they were in `src/` so it's easy to
@@ -280,6 +281,10 @@ changes:
   are linted and the unit tests are executed.
 * `delta:coffeeunit` - When any `*.spec.coffee` file in `src/` changes, the test
   files are linted, compiled their tests executed.
+* `delta:jsfixture` and `delta:coffeefixture` - When any `*.fixture.*` file in
+  `src/` changes, the files are linted and copied to the build folder.
+* `delta:jsscenario` and `delta:coffeescenario` - When any `*.scenario.*` file in
+  `src/` changes, the files are linted.
 
 As covered in the previous section, `grunt watch` will execute a full build
 up-front and then run any of the aforementioned `delta:*` tasks as needed to

--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,8 @@
     "bootstrap": "~2.3.2",
     "angular-bootstrap": "~0.3.0",
     "angular-ui-router": "~0.0.1",
-    "angular-ui-utils": "~0.0.3"
+    "angular-ui-utils": "~0.0.3",
+    "angular-scenario": "~1.0.7"
   },
   "dependencies": {}
 }

--- a/build.config.js
+++ b/build.config.js
@@ -16,15 +16,20 @@ module.exports = {
    * build tasks. `js` is all project javascript, less tests. `ctpl` contains
    * our reusable components' (`src/common`) template HTML files, while
    * `atpl` contains the same, but for our app's code. `html` is just our
-   * main HTML file, `less` is our main stylesheet, and `unit` contains our
-   * app's unit tests.
+   * main HTML file, `less` is our main stylesheet, `unit` contains our
+   * app's unit tests, `fixture` contains $http data fixtures, and `scenario`
+   * contains our app's e2e tests.
    */
   app_files: {
-    js: [ 'src/**/*.js', '!src/**/*.spec.js' ],
+    js: [ 'src/**/*.js', '!src/**/*.spec.js', '!src/**/*.fixture.js', '!src/**/*.scenario.js' ],
     jsunit: [ 'src/**/*.spec.js' ],
+    jsfixture: [ 'src/**/*.fixture.js' ],
+    jsscenario: [ 'src/**/*.scenario.js' ],
     
-    coffee: [ 'src/**/*.coffee', '!src/**/*.spec.coffee' ],
+    coffee: [ 'src/**/*.coffee', '!src/**/*.spec.coffee', '!src/**/*.fixture.coffee', '!src/**/*.scenario.coffee' ],
     coffeeunit: [ 'src/**/*.spec.coffee' ],
+    coffeefixture: [ 'src/**/*.fixture.coffee' ],
+    coffeescenario: [ 'src/**/*.scenario.coffee' ],
 
     atpl: [ 'src/app/**/*.tpl.html' ],
     ctpl: [ 'src/common/**/*.tpl.html' ],
@@ -46,6 +51,9 @@ module.exports = {
    *
    * The `vendor_files.css` property holds any CSS files to be automatically
    * included in our app.
+   *
+   * The `vendor_files.dev` property holds any JS files to be included for
+   * development only.
    */
   vendor_files: {
     js: [
@@ -56,6 +64,9 @@ module.exports = {
       'vendor/angular-ui-utils/modules/route/route.js'
     ],
     css: [
+    ],
+    dev: [
+      'vendor/angular-mocks/angular-mocks.js'
     ]
-  },
+  }
 };

--- a/karma/karma-e2e.tpl.js
+++ b/karma/karma-e2e.tpl.js
@@ -37,8 +37,8 @@ module.exports = function ( karma ) {
      * On which port should the browser connect, on which port is the test runner
      * operating, and what is the URL path for the browser to use.
      */
-    port: 9019,
-    runnerPort: 9101,
+    port: 9020,
+    runnerPort: 9102,
     urlRoot: '/',
 
     /** 

--- a/karma/karma-e2e.tpl.js
+++ b/karma/karma-e2e.tpl.js
@@ -9,22 +9,21 @@ module.exports = function ( karma ) {
      * This is the list of file patterns to load into the browser during testing.
      */
     files: [
-      <% scripts.forEach( function ( file ) { %>'<%= file %>',
-      <% }); %>
-      'src/**/*.js',
-      'src/**/*.coffee'
+      // Include the ng-scenario library and adapter
+      // Remove these when `karma-ng-scenario` can be included:
+      // https://github.com/karma-runner/grunt-karma/issues/13
+      'vendor/angular-scenario/angular-scenario.js',
+      'node_modules/karma-ng-scenario/lib/adapter.js',
+
+      // Include all scenario tests
+      'src/**/*.scenario.*',
+
+      // Serve the contents of the "dist" folder as static files
+      {pattern: '<%= grunt.config( "build_dir" ) %>/**/*', watched: false, included: false, served: true}
     ],
 
-    /**
-     * This is the list of file patterns to exclude from loading.
-     */
-    exclude: [
-      'src/**/*.fixture.*',
-      'src/**/*.scenario.*'
-    ],
-
-    frameworks: [ 'jasmine' ],
-    plugins: [ 'karma-jasmine', 'karma-firefox-launcher', 'karma-chrome-launcher', 'karma-coffee-preprocessor' ],
+    //frameworks: [ 'ng-scenario' ],
+    plugins: [ 'karma-firefox-launcher', 'karma-chrome-launcher', 'karma-coffee-preprocessor' ],
     preprocessors: {
       '**/*.coffee': 'coffee'
     },
@@ -38,14 +37,19 @@ module.exports = function ( karma ) {
      * On which port should the browser connect, on which port is the test runner
      * operating, and what is the URL path for the browser to use.
      */
-    port: 9018,
-    runnerPort: 9100,
+    port: 9019,
+    runnerPort: 9101,
     urlRoot: '/',
 
     /** 
      * Disable file watching by default.
      */
     autoWatch: false,
+
+    /**
+     * Run E2E tests once by default
+     */
+    singleRun: true,
 
     /**
      * The list of browsers to launch to test on. This includes only "Firefox" by

--- a/node_modules/karma-ng-scenario/lib/adapter.js
+++ b/node_modules/karma-ng-scenario/lib/adapter.js
@@ -1,0 +1,100 @@
+/*
+ * Taken from the `karma-ng-scenario` project:
+ * https://github.com/karma-runner/karma-ng-scenario
+ * Should be replaced once the `grunt-karma` project sets `karma` as
+ * a sibling dependency:
+ * https://github.com/karma-runner/grunt-karma/issues/13
+ */
+(function(window) {
+
+  var registerResultListeners = function(model, tc) {
+    var totalTests = 0, testsCompleted = 0;
+
+    var createFailedSpecLog = function(spec) {
+      var failedStep = findFailedStep(spec.steps);
+      var specError = spec.line ? spec.line + ': ' + spec.error.toString() : spec.error.toString();
+
+      return failedStep ? [failedStep.name, specError] : [specError];
+    };
+
+    var findFailedStep = function(steps) {
+      var stepCount = steps.length;
+      for(var i = 0; i < stepCount; i++) {
+        var step = steps[i];
+
+        if (step.status === 'failure') {
+          return step;
+        }
+      }
+
+      return null;
+    };
+
+    model.on('RunnerBegin', function() {
+      totalTests = angular.scenario.Describe.specId;
+      tc.info({total: totalTests});
+    });
+
+    model.on('SpecEnd', function(spec) {
+      // TODO(vojta): create Result type
+      var result = {
+        id: spec.id,
+        description: spec.name,
+        suite: [spec.fullDefinitionName],
+        success: spec.status === 'success',
+        skipped: false,
+        time: spec.duration,
+        log: [],
+        coverage: window.document.getElementsByTagName('iframe')[0].contentWindow.__coverage__
+      };
+
+      if (spec.error) {
+        result.log = createFailedSpecLog(spec);
+      }
+
+      testsCompleted++;
+      tc.result(result);
+    });
+
+    model.on('RunnerEnd', function() {
+      var skippedTests = totalTests - testsCompleted;
+
+      // Inform Karma about number of skipped tests
+      // TODO(vojta): report proper suite/description (need to fix the scenario runner first)
+      for (var i = 0; i < skippedTests; i++) {
+        tc.result({
+          id: 'Skipped' + (i + 1),
+          description: 'Skipped' + (i + 1),
+          suite: [],
+          skipped: true,
+          time: 0,
+          log: []
+        });
+      }
+
+      tc.complete();
+    });
+  };
+
+  /**
+   *
+   * @param {Object} tc Karma!!
+   * @param {Function} scenarioSetupAndRun angular.scenario.setUpAndRun
+   * @return {Function}
+   */
+  var createNgScenarioStartFn = function(tc, scenarioSetupAndRun) {
+    /**
+     * Generates Karma Output
+     */
+    angular.scenario.output('karma', function(context, runner, model) {
+      registerResultListeners(model, tc);
+    });
+
+    return function(config) {
+      scenarioSetupAndRun({scenario_output: 'karma,html'});
+    };
+  };
+
+  window.__karma__.start = createNgScenarioStartFn(window.__karma__, angular.scenario.setUpAndRun);
+
+})(window);

--- a/src/README.md
+++ b/src/README.md
@@ -12,6 +12,8 @@ src/
   |  |- home/
   |  |- app.js
   |  |- app.spec.js
+  |  |- app.fixture.js
+  |  |- app.scenario.js
   |- assets/
   |  |- fonts/
   |- common/

--- a/src/app/README.md
+++ b/src/app/README.md
@@ -9,6 +9,8 @@ src/
   |  |- about/
   |  |- app.js
   |  |- app.spec.js
+  |  |- app.fixture.js
+  |  |- app.scenario.js
 ```
 
 The `src/app` directory contains all code specific to this application. Apart
@@ -89,3 +91,7 @@ One of the design philosophies of `ngBoilerplate` is that tests should exist
 alongside the code they test and that the build system should be smart enough to
 know the difference and react accordingly. As such, the unit test for `app.js`
 is `app.spec.js`, though it is quite minimal.
+
+The e2e test is `app.scenario.js`, and it's data fixtures are `app.fixture.js`.
+Data fixtures will only be included in the build copy, not the compiled copy.
+This way they can be used in development and e2e tests.

--- a/src/app/about/about.fixture.coffee
+++ b/src/app/about/about.fixture.coffee
@@ -1,0 +1,6 @@
+# An example of data fixtures written in CoffeeScript
+angular.module( 'ngBoilerplate.about' ).run( ( $httpBackend ) ->
+  $httpBackend.when( 'POST', '/login' ).respond( () ->
+    [204, '', {}]
+  )
+)

--- a/src/app/about/about.scenario.coffee
+++ b/src/app/about/about.scenario.coffee
@@ -1,0 +1,19 @@
+# An example of an E2E test written in CoffeeScript
+describe( 'ng-boilerplate /about', () ->
+  url = '/base/build/index.html#/about'
+  describe( 'smoke test', () ->
+
+    it( 'initial state', () ->
+      # Trigger state change: Load page
+      browser().navigateTo(url)
+
+      # Check rendered HTML:
+      # ui-view content has correct heading
+      expect(element('div[ui-view="main"] h1', 'content heading').text()).
+      toContain('The Elevator Pitch')
+
+      # Check URL partial: /home
+      expect(browser().window().hash()).toEqual('/about')
+    )
+  )
+)

--- a/src/app/app.fixture.js
+++ b/src/app/app.fixture.js
@@ -1,0 +1,16 @@
+/**
+ * This module is used in development to mock $http calls
+ */
+angular.module( 'ngBoilerplate.dev', [ 'ngBoilerplate', 'ngMockE2E' ]);
+
+/**
+ * This is where you store `$httpBackend.when()` calls
+ * to go with your app's `$http` calls.
+ */
+angular.module( 'ngBoilerplate' ).run( function ( $httpBackend ) {
+  $httpBackend.when( 'POST', '/login' ).respond( function () {
+    return [204, '', {}];
+  });
+})
+
+;

--- a/src/app/app.scenario.js
+++ b/src/app/app.scenario.js
@@ -1,0 +1,21 @@
+/*
+ * This is an e2e test suite.
+ */
+
+describe( 'ng-boilerplate', function() {
+  var url = '/base/build/index.html';
+  describe( 'smoke test', function() {
+
+    it( 'initial state', function () {
+      // Trigger state change: Load page
+      browser().navigateTo(url);
+
+      // Check rendered HTML: Top heading is correct, and ng-view content has correct heading
+      expect(element('div.masthead h3', 'top heading').text()).toContain('ng-boilerplate');
+      expect(element('div[ui-view] h1', 'content heading').text()).toContain('Non-Trivial AngularJS Made Easy');
+
+      // Check URL partial: /home
+      expect(browser().window().hash()).toEqual('/home');
+    });
+  });
+});

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ng-app="ngBoilerplate" ng-controller="AppCtrl">
+<html ng-app="ngBoilerplate<% if (dev) {%>.dev<%}%>" ng-controller="AppCtrl">
   <head>
     <title>ng-boilerplate</title>
 


### PR DESCRIPTION
Tests are defined in `*.scenario.*` files.
Data fixtures defined with `ngMockE2E:$httpBackend.when()` calls are defined in `*.fixture.*` files.
Data fixtures are only included in `build`, for development, not `compile`.
The Karma ng-scenario adapter is statically included as a temporary fix until it can be included as a sibling dependency:
https://github.com/karma-runner/grunt-karma/issues/13
