### PR TITLE
Create source maps for Coffee script files.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -175,7 +175,8 @@ module.exports = function ( grunt ) {
     coffee: {
       source: {
         options: {
-          bare: true
+          bare: true,
+          sourceMap: true
         },
         expand: true,
         cwd: '.',


### PR DESCRIPTION
Make the coffee:source task create [source maps](http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/) for easier debugging in the browser.
