### PR TITLE
Include vendor css files in the build, append vender css to less files in compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 bin/
 node_modules/
 vendor/
+.idea/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -132,9 +132,10 @@ module.exports = function ( grunt ) {
             files: [
                 {
                     src: [ '<%= vendor_files.css %>' ],
-                    dest: '<%= build_dir %>',
+                    dest: '<%= build_dir %>/assets/',
                     cwd: '.',
-                    expand: true
+                    expand: true,
+                    flatten:true
                 }
             ]
         },
@@ -143,7 +144,7 @@ module.exports = function ( grunt ) {
           {
             src: [ '**' ],
             dest: '<%= compile_dir %>/assets',
-            cwd: '<%= build_dir %>/assets',
+            cwd: 'src/assets',
             expand: true
           }
         ]
@@ -245,7 +246,7 @@ module.exports = function ( grunt ) {
       },
       compile: {
         src: [ '<%= recess.build.dest %>', '<%= vendor_files.css%>' ],
-        dest: '<%= recess.build.dest %>',
+        dest: '<%= compile_dir %>/assets/<%= pkg.name %>.css',
         options: {
           compile: true,
           compress: true,
@@ -369,8 +370,7 @@ module.exports = function ( grunt ) {
           '<%= build_dir %>/src/**/*.js',
           '<%= html2js.common.dest %>',
           '<%= html2js.app.dest %>',
-          '<%= vendor_files.css %>',
-          '<%= recess.build.dest %>'
+          '<%= build_dir %>/assets/*.css'
         ]
       },
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -128,6 +128,16 @@ module.exports = function ( grunt ) {
           }
         ]
       },
+        build_vendorcss: {
+            files: [
+                {
+                    src: [ '<%= vendor_files.css %>' ],
+                    dest: '<%= build_dir %>',
+                    cwd: '.',
+                    expand: true
+                }
+            ]
+        },
       compile_assets: {
         files: [
           {
@@ -234,7 +244,7 @@ module.exports = function ( grunt ) {
         }
       },
       compile: {
-        src: [ '<%= recess.build.dest %>' ],
+        src: [ '<%= recess.build.dest %>', '<%= vendor_files.css%>' ],
         dest: '<%= recess.build.dest %>',
         options: {
           compile: true,
@@ -373,7 +383,6 @@ module.exports = function ( grunt ) {
         dir: '<%= compile_dir %>',
         src: [
           '<%= concat.compile_js.dest %>',
-          '<%= vendor_files.css %>',
           '<%= recess.compile.dest %>'
         ]
       }
@@ -540,8 +549,8 @@ module.exports = function ( grunt ) {
    */
   grunt.registerTask( 'build', [
     'clean', 'html2js', 'jshint', 'coffeelint', 'coffee','recess:build',
-    'copy:build_assets', 'copy:build_appjs', 'copy:build_vendorjs',
-    'index:build', 'karmaconfig', 'karma:continuous' 
+    'copy:build_assets', 'copy:build_appjs', 'copy:build_vendorjs', 'copy:build_vendorcss',
+    'index:build', 'karmaconfig', 'karma:continuous'
   ]);
 
   /**

--- a/src/index.html
+++ b/src/index.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" href="assets/font-awesome-ie7.min.css />
     <![endif]-->
 
-    <!-- compiled CSS --><% scripts.forEach( function ( file ) { %>
+    <!-- compiled JavaScript --><% scripts.forEach( function ( file ) { %>
     <script type="text/javascript" src="<%= file %>"></script><% }); %>
 
     <!-- it's stupid to have to load it here, but this is for the +1 button -->


### PR DESCRIPTION
fixes #57

addresses #95 - still an issue as the relative referecnes to images are
different in the build and the compiled versions
