### PR TITLE
Allow js files to be added to the assets directory

### DIFF
--- a/build.config.js
+++ b/build.config.js
@@ -20,7 +20,7 @@ module.exports = {
    * app's unit tests.
    */
   app_files: {
-    js: [ 'src/**/*.js', '!src/**/*.spec.js' ],
+    js: [ 'src/**/*.js', '!src/**/*.spec.js', '!src/assets/**/*.js' ],
     jsunit: [ 'src/**/*.spec.js' ],
     
     coffee: [ 'src/**/*.coffee', '!src/**/*.spec.coffee' ],

--- a/karma/karma-unit.tpl.js
+++ b/karma/karma-unit.tpl.js
@@ -14,7 +14,9 @@ module.exports = function ( karma ) {
       'src/**/*.js',
       'src/**/*.coffee',
     ],
-
+    exclude: [
+      'src/assets/**/*.js'
+    ],
     frameworks: [ 'jasmine' ],
     plugins: [ 'karma-jasmine', 'karma-firefox-launcher', 'karma-chrome-launcher', 'karma-coffee-preprocessor' ],
     preprocessors: {


### PR DESCRIPTION
without them being linted or added to karma tests...

In some cases I need to load 3rd party js files into the application that aren't compiled with the rest.

These files are already minified and fail the js linting, this change means that they are excluded from the js checks and karma running
