### PR TITLE
Added karma-phantomjs-launcher plugin for PhantomJS support.

### DIFF
--- a/karma/karma-unit.tpl.js
+++ b/karma/karma-unit.tpl.js
@@ -16,7 +16,7 @@ module.exports = function ( karma ) {
     ],
 
     frameworks: [ 'jasmine' ],
-    plugins: [ 'karma-jasmine', 'karma-firefox-launcher', 'karma-chrome-launcher', 'karma-coffee-preprocessor' ],
+    plugins: [ 'karma-jasmine', 'karma-firefox-launcher', 'karma-chrome-launcher', 'karma-phantomjs-launcher', 'karma-coffee-preprocessor' ],
     preprocessors: {
       '**/*.coffee': 'coffee',
     },


### PR DESCRIPTION
To use PhantomJS, change the Karma browsers config and install PhantomJS, if necessary, by running 'npm install --save-dev phantomjs' and seting the PHANTOMJS_BIN environment variable.
