### PR TITLE
Ng1.2wip

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,12 +2,12 @@
   "name": "ng-boilerplate",
   "version": "0.3.0",
   "devDependencies": {
-    "angular": "~1.0.7",
-    "angular-mocks": "~1.0.7",
+    "angular": "~1.2.0",
+    "angular-mocks": "~1.2.0",
     "bootstrap": "~2.3.2",
-    "angular-bootstrap": "~0.3.0",
+    "angular-bootstrap": "~0.5.0",
     "angular-ui-router": "~0.0.1",
-    "angular-ui-utils": "~0.0.3"
+    "angular-ui-utils": "~0.0.4"
   },
   "dependencies": {}
 }

--- a/karma/karma-unit.tpl.js
+++ b/karma/karma-unit.tpl.js
@@ -1,5 +1,5 @@
 module.exports = function ( karma ) {
-  karma.configure({
+  karma.set({
     /** 
      * From where to look for files, starting with the location of this file.
      */
@@ -53,7 +53,7 @@ module.exports = function ( karma ) {
      * the aesthetic advantage of not launching a browser every time you save.
      */
     browsers: [
-      'Firefox'
+      'Chrome'
     ]
   });
 };

--- a/karma/karma-unit.tpl.js
+++ b/karma/karma-unit.tpl.js
@@ -53,7 +53,7 @@ module.exports = function ( karma ) {
      * the aesthetic advantage of not launching a browser every time you save.
      */
     browsers: [
-      'Chrome'
+      'Firefox'
     ]
   });
 };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "grunt-contrib-watch": "~0.4.0",
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-karma": "~0.5.0",
-    "grunt-ngmin": "0.0.2",
+    "grunt-ngmin": "0.0.3",
     "grunt-html2js": "~0.1.3",
     "grunt-contrib-coffee": "~0.7.0",
     "grunt-coffeelint": "0.0.6",


### PR DESCRIPTION
Update angular and angular-mocks versions to 1.2.0.

Update ng-min task on Grunt, angular-boostrap and angular-ui-utils to the latest version.

Change karma.configure to karma.set due to warnings that configure was deprecated.
