### PR TITLE
Add fonts into the build process

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -128,6 +128,16 @@ module.exports = function ( grunt ) {
           }
         ]
       },
+      copy_vendor_assets: {
+        files: [
+          {
+            src: [ '<%= vendor_files.font %>' ],
+            dest: '<%= build_dir %>/assets',
+            cwd: '.',
+            expand: true
+          }
+        ]
+      },
       compile_assets: {
         files: [
           {
@@ -360,6 +370,7 @@ module.exports = function ( grunt ) {
           '<%= html2js.common.dest %>',
           '<%= html2js.app.dest %>',
           '<%= vendor_files.css %>',
+          '<%= vendor_files.font %>',
           '<%= recess.build.dest %>'
         ]
       },
@@ -374,6 +385,7 @@ module.exports = function ( grunt ) {
         src: [
           '<%= concat.compile_js.dest %>',
           '<%= vendor_files.css %>',
+          '<%= vendor_files.font %>',          
           '<%= recess.compile.dest %>'
         ]
       }
@@ -540,7 +552,7 @@ module.exports = function ( grunt ) {
    */
   grunt.registerTask( 'build', [
     'clean', 'html2js', 'jshint', 'coffeelint', 'coffee','recess:build',
-    'copy:build_assets', 'copy:build_appjs', 'copy:build_vendorjs',
+    'copy:build_assets', 'copy:build_appjs', 'copy:build_vendorjs', 'copy:copy_vendor_assets',
     'index:build', 'karmaconfig', 'karma:continuous' 
   ]);
 

--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,8 @@
     "bootstrap": "~2.3.2",
     "angular-bootstrap": "~0.3.0",
     "angular-ui-router": "~0.0.1",
-    "angular-ui-utils": "~0.0.3"
+    "angular-ui-utils": "~0.0.3",
+    "roboto-fontface": "~0.1.2"
   },
   "dependencies": {}
 }

--- a/build.config.js
+++ b/build.config.js
@@ -56,6 +56,9 @@ module.exports = {
       'vendor/angular-ui-utils/modules/route/route.js'
     ],
     css: [
+    ],
+    font: [
+      'vendor/roboto-fontface/fonts/Roboto-Regular.woff'
     ]
   },
 };

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -41,7 +41,7 @@
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 400;
-  src: local('Roboto Regular'), local('Roboto-Regular'), url(fonts/Roboto-Regular.woff) format('woff');
+  src: local('Roboto Regular'), local('Roboto-Regular'), url(vendor/roboto-fontface/fonts/Roboto-Regular.woff) format('woff');
 }
 
 code, pre, .pre {


### PR DESCRIPTION
Changes to add font handling into the gruntfile and to the build scripts.

I have to say it's the first time working with grunt files for me, so whilst this works, I'm not 100% confident it's the right way to go about it.  I've mainly gone with a monkey-see monkey-do approach to the vendor_files.css logic.

I've also needed to change the main.less to expect the font to be in a different location - another option would clearly be to put the font in the location that it's expecting, but my gruntfile skills ran out of depth at about that point.
