### PR TITLE
Karma.unit.port

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,5 @@
 module.exports = function ( grunt ) {
+
   
   /** 
    * Load required Grunt tasks. These are installed based on the versions listed
@@ -353,7 +354,7 @@ module.exports = function ( grunt ) {
         configFile: '<%= build_dir %>/karma-unit.js'
       },
       unit: {
-        runnerPort: 9101,
+        port: 9019,
         background: true
       },
       continuous: {

--- a/karma/karma-unit.tpl.js
+++ b/karma/karma-unit.tpl.js
@@ -1,5 +1,5 @@
 module.exports = function ( karma ) {
-  karma.configure({
+  karma.set({
     /** 
      * From where to look for files, starting with the location of this file.
      */

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-watch": "~0.4.0",
     "grunt-contrib-uglify": "~0.2.0",
-    "grunt-karma": "~0.5.0",
+    "grunt-karma": "~0.7.1",
     "grunt-ngmin": "0.0.2",
     "grunt-html2js": "~0.1.3",
     "grunt-contrib-coffee": "~0.7.0",


### PR DESCRIPTION
changing the runnerPort to use port instead in `Gruntfile.js`
as `configure` is deprecated, changing to use `set` instead
