### PR TITLE
CSS should be concat'd in the watch on less change

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -506,7 +506,7 @@ module.exports = function ( grunt ) {
        */
       less: {
         files: [ 'src/**/*.less' ],
-        tasks: [ 'recess:build' ]
+        tasks: [ 'recess:build','concat:build_css' ]
       },
 
       /**


### PR DESCRIPTION
I have added concatenate css files after the less compilation in the 'delta' task to fix the issue mentioned in https://github.com/ngbp/ng-boilerplate/issues/57
