### PR TITLE
feat(less): Automate importing src/app and src/common less files into main.less

### DIFF
--- a/build.config.js
+++ b/build.config.js
@@ -62,11 +62,6 @@ module.exports = {
    */
   vendor_files: {
     js: [
-      'vendor/angular/angular.js',
-      'vendor/angular-bootstrap/ui-bootstrap-tpls.min.js',
-      'vendor/placeholders/angular-placeholders-0.0.1-SNAPSHOT.min.js',
-      'vendor/angular-ui-router/release/angular-ui-router.js',
-      'vendor/angular-ui-utils/modules/route/route.js'
     ],
     css: [
     ],

--- a/build.dependencies.js
+++ b/build.dependencies.js
@@ -1,0 +1,167 @@
+module.exports = function( grunt, user_config ) {
+  // ------------------------------------------------------------------------ Private Variables
+  var bower_dep_reg_expr  = /["|']([^("|')]*)["|']\:[\s]*["|']([^("|')]*)["|']/;
+
+  // ------------------------------------------------------------------------ Init Function
+  function init () {
+    register_tasks();
+    export_config_variables();
+  }
+
+  // ------------------------------------------------------------------------ Private Functions
+  function add_vendor_files_for_module (file_path) {
+    var dependencies        = grunt.config.data.vendor_files,
+      module_dependencies = require( './' + file_path);
+
+    if ( module_dependencies != null && module_dependencies.vendor_files != null ) {
+      if ( module_dependencies.vendor_files.js != null ) {
+        merge_array( module_dependencies.vendor_files.js, dependencies.js );
+      }
+      if ( module_dependencies.vendor_files.css != null ) {
+        merge_array( module_dependencies.vendor_files.css, dependencies.css );
+      }
+      if ( module_dependencies.vendor_files.assets != null ) {
+        merge_array( module_dependencies.vendor_files.assets, dependencies.assets );
+      }
+    }
+  }
+
+  function export_config_variables () {
+    var reduce = user_config.reduce || {};
+
+    reduce.bower_dev_dependencies  = function ( dependencies, file_path, index, array ) {
+      var module_dependencies = require( "./" + file_path );
+
+      if (  module_dependencies != null &&
+        module_dependencies.bower != null &&
+        module_dependencies.bower.devDependencies != null
+        ) {
+        merge_bower_dependencies( dependency_hash_to_list(module_dependencies.bower.devDependencies), dependencies );
+      }
+
+      return ( index !== array.length - 1 ) ? dependencies : '"devDependencies": {\n    ' + dependencies.join(',\n    ') + '\n  }';
+    }
+
+    user_config.reduce = reduce;
+  }
+
+  function merge_bower_dependencies ( from, to ) {
+    var i;
+
+    for ( i = 0; i < from.length; i+=1 ) {
+      dependency = from[i];
+      merge_bower_dependency( dependency, to);
+    }
+
+    return to;
+  }
+
+  function merge_bower_dependency ( dependency, dependencies ) {
+    var name    = get_dependency_name( dependency),
+      version = get_dependency_version( dependency),
+      index   = index_of_dependency(name, dependencies);
+
+    if (index === -1) {
+      dependencies.push(dependency);
+    } else if ( greater_version( version, get_dependency_version( dependencies[index] ) ) === version ) {
+      dependencies[index] = dependency; // prioritize the latest release
+    }
+
+    return dependencies;
+  }
+
+  function register_tasks () {
+    grunt.registerTask( 'process_dependencies', ['import:bower_dev_dependencies', 'update_vendor_files'] );
+
+    grunt.registerTask( 'update_vendor_files', function () {
+      grunt.file.expand('src/**/.dependencies.js')
+        .forEach( add_vendor_files_for_module );
+    });
+  }
+
+  function sanatize_version_array (val) {
+    if (val.length > 0) {
+      val[0] = val[0].replace( /\~/, '' );
+    }
+    return val;
+  }
+
+  // ------------------------------------------------------------------------ Helper Functions
+  function dependency_hash_to_list ( hash ) {
+    var key,
+      list = [];
+
+    for (key in hash) {
+      if ( hash.hasOwnProperty( key ) ) {
+        list.push('"' + key + '"' + ': ' + '"' + hash[key] + '"');
+      }
+    }
+
+    return list;
+  }
+
+  function get_dependency_name ( dependency ) {
+    var match = dependency.match( bower_dep_reg_expr );
+    return (match != null && match.length >= 3) ? match[1] : "";
+  }
+
+  function get_dependency_version ( dependency ) {
+    var match = dependency.match( bower_dep_reg_expr );
+    return (match != null && match.length >= 3) ? match[2] : "0.0.0";
+  }
+
+  function greater_version ( version_a, version_b ) {
+    var i, a, b,
+      split_a   = version_a.split('.'),
+      split_b   = version_b.split('.'),
+      length_a  = split_a.length,
+      length_b  = split_b.length;
+
+    sanatize_version_array( split_a );
+    sanatize_version_array( split_b );
+
+    for ( i = 0; i < length_a; i += 1 ) {
+      a = Number(split_a[i]);
+      b = Number(split_b[i]);
+
+      if ( i > length_b - 1 ) {
+        return version_a; // greater_version('3.1.1', '3.1') -> '3.1.1'
+      } else if ( a > b ) {
+        return version_a;
+      } else if ( b > a ) {
+        return version_b;
+      } else if ( i === length_a - 1 && length_b > length_a ) {
+        return version_b;  // greater_version('3.1', '3.1.1') -> '3.1.1'
+      }
+    }
+
+    return version_a; // greater_version('3.1.1', '3.1.1') -> '3.1.1'
+  }
+
+  function index_of_dependency ( name, dependencies ) {
+    var i;
+    for ( i = 0; i < dependencies.length; i++ ) {
+      if ( get_dependency_name( dependencies[i] ) === name ) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  function merge_array (from, to) {
+    var i;
+
+    if ( from != null && to != null ) {
+      for ( i = 0; i < from.length; i += 1 ) {
+        if ( to.indexOf( from[i] ) === -1 ) {
+          to.push( from[i] );
+        }
+      }
+    }
+
+    return to;
+  }
+
+  // ------------------------------------------------------------------------ init()
+  init();
+};

--- a/build.styles.js
+++ b/build.styles.js
@@ -1,0 +1,35 @@
+module.exports = function( grunt, user_config ) {
+  // ------------------------------------------------------------------------ Private Variables
+
+  // ------------------------------------------------------------------------ Init Function
+  function init () {
+    register_tasks();
+    export_config_variables();
+  }
+
+  // ------------------------------------------------------------------------ Private Functions
+  function export_config_variables () {
+    user_config.app_files.temp_less = user_config.utilities.createTempPath( user_config.app_files.less );
+
+    var reduce = user_config.reduce || {};
+
+    reduce.module_less_imports = function ( previousValue, currentValue, index, array ) {
+      return  previousValue +
+        ( index !== 0 ? '\n' : '' ) +
+        '@import \'' +
+        currentValue.replace( 'src', '..' ) +
+        '\';';
+    };
+
+    user_config.reduce = reduce;
+  }
+
+  function register_tasks () {
+    grunt.registerTask( 'build_styles', ['copy:main_less', 'import:styles', 'recess:build', 'delete:main_less_copy', 'concat:build_css']);
+  }
+
+  // ------------------------------------------------------------------------ Helper Functions
+
+  // ------------------------------------------------------------------------ init()
+  init();
+};

--- a/build.utilities.js
+++ b/build.utilities.js
@@ -1,0 +1,14 @@
+module.exports = function( grunt, user_config ) {
+  var utilities = user_config.utilities || {};
+
+  /**
+   * A utility function to convert a path to a temporary path for copying a file to.
+   */
+  utilities.createTempPath = function ( in_path ) {
+    return in_path.split( '/' ).reduce( function (previousValue, currentValue, index, array ) {
+      return previousValue + ( index !== 0 ? '/' : '' ) + (index === array.length - 1 ? '__TEMP__' : '') + currentValue;
+    }, '' );
+  }
+
+  user_config.utilities = utilities;
+};

--- a/src/app/.dependencies.js
+++ b/src/app/.dependencies.js
@@ -1,0 +1,25 @@
+module.exports = {
+  bower: {
+    devDependencies: {
+      "angular": "~1.0.7",
+      "angular-mocks": "~1.0.7",
+      "bootstrap": "~2.3.2",
+      "angular-bootstrap": "~0.3.0",
+      "angular-ui-router": "~0.0.1",
+      "angular-ui-utils": "~0.0.3"
+    }
+  },
+  vendor_files: {
+    js: [
+      'vendor/angular/angular.js',
+      'vendor/angular-bootstrap/ui-bootstrap-tpls.min.js',
+      'vendor/placeholders/angular-placeholders-0.0.1-SNAPSHOT.min.js',
+      'vendor/angular-ui-router/release/angular-ui-router.js',
+      'vendor/angular-ui-utils/modules/route/route.js'
+    ],
+    css: [
+    ],
+    assets: [
+    ]
+  }
+};

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -150,13 +150,4 @@ h2 {
   }
 }
 
-
-/**
- * Now that all app-wide styles have been applied, we can load the styles for
- * all the submodules and components we are using. 
- *
- * TODO: In a later version of this boilerplate, I'd like to automate this.
- */
-
-@import '../app/home/home.less';
-
+///<module_styles>


### PR DESCRIPTION
Any less files found in 'src/app' and 'src/common' will be automatically imported into the base of the 'src/less/main.less' file at build time.

To achieve this the build process must make a temporary copy of the main.less file, append a string of imports to the base of this file, use it as the target of the recess compilation process, and then then delete the temporary file. 

This may not be the most ideal solution, but it allows users to drag and drop folders into their projects 'app' and 'common' directories without worrying about adding their less imports to the main.less file.

The advantage to including the less files as imports is that the 'src/app' less files can still exploit any less variables that have been defined in app.less. However, this approach may encourage bad practices with the 'src/common' less files.
