### PR TITLE
fix(test watch): Fixed the watch task for use with unit test, issue #100.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -549,12 +549,12 @@ module.exports = function ( grunt ) {
    * before watching for changes.
    */
   grunt.renameTask( 'watch', 'delta' );
-  grunt.registerTask( 'watch', [ 'build', 'karma:unit', 'delta' ] );
+  grunt.registerTask( 'watch', [ 'build', 'karmaconfig', 'karma:unit', 'delta' ] );
 
   /**
    * The default task is to build and compile.
    */
-  grunt.registerTask( 'default', [ 'build', 'compile' ] );
+  grunt.registerTask( 'default', [ 'build', 'test', 'compile' ] );
 
   /**
    * The `build` task gets your app ready to run for development and testing.
@@ -562,8 +562,14 @@ module.exports = function ( grunt ) {
   grunt.registerTask( 'build', [
     'clean', 'html2js', 'jshint', 'coffeelint', 'coffee', 'recess:build',
     'concat:build_css', 'copy:build_app_assets', 'copy:build_vendor_assets',
-    'copy:build_appjs', 'copy:build_vendorjs', 'index:build', 'karmaconfig',
-    'karma:continuous' 
+    'copy:build_appjs', 'copy:build_vendorjs', 'index:build'
+  ]);
+
+   /**
+   * The `test` task tests your app.
+   */
+  grunt.registerTask( 'test', [
+    'karmaconfig', 'karma:continuous'
   ]);
 
   /**


### PR DESCRIPTION
The bug came from that karma starts its task two times. Once in the build task and once in the watch task. This automatically bumps the port from 9018 to 9019. I put the testing in its own task, added it to the default task, and added karmaconfig to the watch task to initialize the test.
Now users can run: 
  grunt watch --force
to have tests running automatically when a file is saved.
