### PR TITLE
Fixed copy of assets in delta config

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -479,7 +479,7 @@ module.exports = function ( grunt ) {
         files: [ 
           'src/assets/**/*'
         ],
-        tasks: [ 'copy:build_assets' ]
+        tasks: [ 'copy:build_app_assets', 'copy:build_vendor_assets' ]
       },
 
       /**


### PR DESCRIPTION
Commit 29502bff8eb649501945aef37fe50d81c36151ba broke the copying of assets from the delta task.
Instead of doing copy:build_assets, we need to do copy:build_app_assets and copy:build_vendor_assets.
