### PR TITLE
prevent uglify from messing up with angular provider

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -229,6 +229,7 @@ module.exports = function ( grunt ) {
     uglify: {
       compile: {
         options: {
+          mangle: false,
           banner: '<%= meta.banner %>'
         },
         files: {


### PR DESCRIPTION
As explained here:
http://stackoverflow.com/questions/17238759/angular-module-minification-bug?answertab=votes#tab-top
