### PR TITLE
fix(Gruntfile): Exclude vendor CSS from index.html template

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -380,7 +380,6 @@ module.exports = function ( grunt ) {
           '<%= build_dir %>/src/**/*.js',
           '<%= html2js.common.dest %>',
           '<%= html2js.app.dest %>',
-          '<%= vendor_files.css %>',
           '<%= recess.build.dest %>'
         ]
       },
@@ -394,7 +393,6 @@ module.exports = function ( grunt ) {
         dir: '<%= compile_dir %>',
         src: [
           '<%= concat.compile_js.dest %>',
-          '<%= vendor_files.css %>',
           '<%= recess.compile.dest %>'
         ]
       }


### PR DESCRIPTION
Vendor CSS file list was being generated and redundantly included in the index.html template despite a previous commit that ensured vendor CSS files were concatenated into the main CSS file for both build and compile.

This pull request rectifies this by excluding vendor CSS files from being included in the index.html template.
