### PR TITLE
Updated grunt-contrib-jshint to 0.8.0 (jshint 2.4.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "grunt-recess": "~0.3.0",
     "grunt-contrib-clean": "~0.4.1",
     "grunt-contrib-copy": "~0.4.1",
-    "grunt-contrib-jshint": "~0.4.3",
+    "grunt-contrib-jshint": "~0.8.0",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-watch": "~0.4.0",
     "grunt-contrib-uglify": "~0.2.0",


### PR DESCRIPTION
The 0.4.3 release uses JSHint 1.1.0, whereas 0.8.0 uses the latest 2.4.0 release. This is especially useful since JSHint 2.x has EcmaScript 5 as the default (along with supporting some ES6 stuff).
