### PR TITLE
Add connect task into grunt watch to start developer server

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,6 +9,7 @@ module.exports = function ( grunt ) {
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-contrib-watch');
+  grunt.loadNpmTasks('grunt-contrib-connect');
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-coffee');
   grunt.loadNpmTasks('grunt-conventional-changelog');
@@ -536,6 +537,20 @@ module.exports = function ( grunt ) {
           livereload: false
         }
       }
+    },
+
+    /**
+     * Server config
+     */
+    connect: {
+      server: {
+        options: {
+          port: '<%= server.port %>',
+          hostname: '<%= server.hostname %>',
+          base: './<%= build_dir %>',
+          open: true
+        }
+      }
     }
   };
 
@@ -549,7 +564,7 @@ module.exports = function ( grunt ) {
    * before watching for changes.
    */
   grunt.renameTask( 'watch', 'delta' );
-  grunt.registerTask( 'watch', [ 'build', 'karma:unit', 'delta' ] );
+  grunt.registerTask( 'watch', [ 'build', 'karma:unit', 'connect', 'delta' ] );
 
   /**
    * The default task is to build and compile.

--- a/build.config.js
+++ b/build.config.js
@@ -11,6 +11,15 @@ module.exports = {
   compile_dir: 'bin',
 
   /**
+   * This is server config. Define port and hostname.
+   * It will be used in grunt connect task for developer server.
+   */
+  server: {
+    port: 3333,
+    hostname: 'localhost'
+  },
+
+  /**
    * This is a collection of file patterns that refer to our app code (the
    * stuff in `src/`). These file paths are used in the configuration of
    * build tasks. `js` is all project javascript, less tests. `ctpl` contains

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "grunt-contrib-jshint": "~0.4.3",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-watch": "~0.4.0",
+    "grunt-contrib-connect": "~0.6.0",
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-karma": "~0.5.0",
     "grunt-ngmin": "0.0.2",


### PR DESCRIPTION
Hi everyone.
I suggest to add [connect](https://github.com/gruntjs/grunt-contrib-connect) task into Gruntfile to start local server when `grunt watch` happened. In build.config.js I've added server setting for configure hostname and port.
I think, it will be more useful than `cd build && python -m SimpleHTTPServer 8080` (for e.x.), because with `grunt connect` we able to configure [proxy](https://github.com/drewzboto/grunt-connect-proxy) for work with some api.
