### PR TITLE
(docs) npm -g install > npm install -g

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Install Node.js and then:
 ```sh
 $ git clone git://github.com/joshdmiller/ng-boilerplate
 $ cd ng-boilerplate
-$ sudo npm -g install grunt-cli karma bower
+$ sudo npm install -g grunt-cli karma bower
 $ npm install
 $ bower install
 $ grunt watch


### PR DESCRIPTION
`npm -g install` will not install anything. Fixed to `npm install -g`
