### PR TITLE
Link to travis page doesn't exist. Remove/Fix?

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [ngBoilerplate](http://joshdmiller.github.com/ng-boilerplate) [![Build Status](https://travis-ci.org/joshdmiller/ng-boilerplate.png?branch=master)](https://travis-ci.org/joshdmiller/ng-boilerplate)
+# [ngBoilerplate](http://joshdmiller.github.com/ng-boilerplate) [![Build Status](https://travis-ci.org/joshdmiller/ng-boilerplate.png?branch=master)](https://travis-ci.org/joshdmiller/ng-boilerplate) <-- this link doesn't exist.
 
 An opinionated kickstarter for [AngularJS](http://angularjs.org) projects.
 


### PR DESCRIPTION
I tried searching Travis for ng-boilerplate and joshdmiller too but couldn't find the correct link, so I couldn't correct it.
