### PR TITLE
Bump grunt-coffeelint to ~0.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "grunt-ngmin": "0.0.2",
     "grunt-html2js": "~0.1.3",
     "grunt-contrib-coffee": "~0.7.0",
-    "grunt-coffeelint": "0.0.6",
+    "grunt-coffeelint": "~0.0.10",
     "grunt-conventional-changelog": "~0.1.1",
     "grunt-bump": "0.0.6"
   }


### PR DESCRIPTION
The updated version of grunt-coffeelint has a useful option to refer to a coffeelint configuration file via `options: {configFile: 'coffeelint.json'}`.
