### PR TITLE
removed vendor css from index tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -380,7 +380,6 @@ module.exports = function ( grunt ) {
           '<%= build_dir %>/src/**/*.js',
           '<%= html2js.common.dest %>',
           '<%= html2js.app.dest %>',
-          '<%= vendor_files.css %>',
           '<%= recess.build.dest %>'
         ]
       },
@@ -394,7 +393,6 @@ module.exports = function ( grunt ) {
         dir: '<%= compile_dir %>',
         src: [
           '<%= concat.compile_js.dest %>',
-          '<%= vendor_files.css %>',
           '<%= recess.compile.dest %>'
         ]
       }


### PR DESCRIPTION
Hey - issue I have been having. When I add a CSS file to **build.config.js** under **vendor_files.css**
- Grunt Watch is not watching build.config for additions, so I have to restart grunt watch (may be unrelated to the issue)
- Restarting Grunt Watch runs **concat:build** and **index:build**
  - **concat:build_css** adds **vendor_files.css** to the giant app css file **not** as a separate file
  - **index:build** adds the path for what would be a separate file of vendor css to the head of index.html
- The appropriate css is now in the concatenated file, but the app throws an error as it also looks for the actual vendor file in the build directory. 
- This also happens with the compile task. 

My fix - quick and dirty, delete **<% vendor_files.css %>** from **index:build** and **index:compile**. The CSS is already in the concatenated file, so these paths don't need to be added to index.html. I know there's a lot going on under the hood with the grunt task, so I'd love to hear if this is a bug, if I'm using grunt build/compile in the intended way, etc. 

An example: 
1. CSS is added to vendor_files
![screen shot 2014-04-09 at 5 25 56 pm](https://cloud.githubusercontent.com/assets/4284340/2661578/bd79a248-c02e-11e3-85b2-01b749fc63cb.png)
2. On restart of grunt watch, error is thrown as app is looking for the file in the build/vendor folder. 
![screen shot 2014-04-09 at 5 26 18 pm](https://cloud.githubusercontent.com/assets/4284340/2661585/d44d64fa-c02e-11e3-871f-1ad4e64a3d87.png)
This is because the path has been added to index.html. 
![screen shot 2014-04-09 at 5 26 51 pm](https://cloud.githubusercontent.com/assets/4284340/2661587/d833cb4a-c02e-11e3-965b-9d4365491745.png)
3. App is still working fine because actual CSS has been added to big concatenated file
![screen shot 2014-04-09 at 5 27 33 pm](https://cloud.githubusercontent.com/assets/4284340/2661595/00a59afe-c02f-11e3-9ea9-2d8f4b359833.png)
