### PR TITLE
Removed adding vendor css files to head

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -372,7 +372,6 @@ module.exports = function ( grunt ) {
           '<%= build_dir %>/src/**/*.js',
           '<%= html2js.common.dest %>',
           '<%= html2js.app.dest %>',
-          '<%= vendor_files.css %>',
           '<%= build_dir %>/assets/<%= pkg.name %>-<%= pkg.version %>.css'
         ]
       },


### PR DESCRIPTION
During the build process, references to the vendor css files were placed in the head section.
However, this was an unnecessary step => vendor css files are added to the concatenated css file (row 375), resulting in errors (css files not found) in the browser. This commit removes the adding of these files to the head section.
