### PR TITLE
Replace ngmin with ng-annotate

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,7 +16,7 @@ module.exports = function ( grunt ) {
   grunt.loadNpmTasks('grunt-bump');
   grunt.loadNpmTasks('grunt-coffeelint');
   grunt.loadNpmTasks('grunt-karma');
-  grunt.loadNpmTasks('grunt-ngmin');
+  grunt.loadNpmTasks('grunt-ng-annotate');
   grunt.loadNpmTasks('grunt-html2js');
 
   /**
@@ -223,10 +223,10 @@ module.exports = function ( grunt ) {
     },
 
     /**
-     * `ng-min` annotates the sources before minifying. That is, it allows us
+     * `ngAnnotate` annotates the sources before minifying. That is, it allows us
      * to code without the array syntax.
      */
-    ngmin: {
+    ngAnnotate: {
       compile: {
         files: [
           {
@@ -579,7 +579,7 @@ module.exports = function ( grunt ) {
    * minifying your code.
    */
   grunt.registerTask( 'compile', [
-    'less:compile', 'copy:compile_assets', 'ngmin', 'concat:compile_js', 'uglify', 'index:compile'
+    'less:compile', 'copy:compile_assets', 'ngAnnotate', 'concat:compile_js', 'uglify', 'index:compile'
   ]);
 
   /**

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "grunt-contrib-concat": "^0.3.0",
     "grunt-contrib-watch": "^0.4.4",
     "grunt-contrib-uglify": "^0.2.7",
-    "grunt-ngmin": "0.0.2",
+    "grunt-ng-annotate": "^0.8.0",
     "grunt-html2js": "^0.1.9",
     "grunt-contrib-coffee": "^0.7.0",
     "grunt-coffeelint": "~0.0.10",


### PR DESCRIPTION
ngmin doesn't annotate dependencies in resolves on a ui-router state and ng-annotate does. Using states is a big part of the ngbp project structure. Also, ng-annotate is faster and more robust. 

Furthermore, @btford is okay with deprecating ngmin and nominating ng-annotate as it's successor. See btford/ngmin#93, specifically https://github.com/btford/ngmin/issues/93#issuecomment-43699038
