### PR TITLE
reserved vendor assets structure upon building

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -112,10 +112,10 @@ module.exports = function ( grunt ) {
         files: [
           { 
             src: [ '<%= vendor_files.assets %>' ],
-            dest: '<%= build_dir %>/assets/',
+            dest: '<%= build_dir %>/',
             cwd: '.',
             expand: true,
-            flatten: true
+            flatten: false
           }
        ]   
       },


### PR DESCRIPTION
There are already a few issues https://github.com/ngbp/ngbp/issues/278, https://github.com/ngbp/ngbp/issues/218 regarding the vendor assets structure.

This commit made the vendor assets preserve the structure when building.
