### PR TITLE
Update README.md with the correct grunt.js link

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ of the tools](tools.md) before continuing with this section.
 
 Okay, ready to go? Here it is:
 
-`ngBoilerplate` uses [Grunt](http://gruntjs.org) as its build system, so
+`ngBoilerplate` uses [Grunt](http://gruntjs.com) as its build system, so
 [Node.js](http://nodejs.org) is required. Also, Grunt by default no longer comes
 with a command-line utility and Karma and Bower must end up in your global path
 for the build system to find it, so they must be installed independently. Once


### PR DESCRIPTION
grunt.org is in some asian language, grunt.com is the english version
