### PR TITLE
changing .gitignore to only ignore bin and build directories created by ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.sw*
 *~
-build/
-bin/
+/build
+/bin
 node_modules/
 vendor/


### PR DESCRIPTION
For those who decide to commit their npm dependencies the current .gitignore for the bin directory breaks the karma module as there are multiple bin directories required. A simple fix is to only ignore the main bin directory "/bin" instead of "bin/" Then if a developer wants to include node_modules and vendor directories they only have to comment out those specific dirs from the .gitignore. A very simple fix for an otherwise time consuming issue to debug.

[NPMJS.org](https://www.npmjs.org/doc/misc/npm-faq.html#Should-I-check-my-node_modules-folder-into-git)

[FutureAloof.com](http://www.futurealoof.com/posts/nodemodules-in-git.html)

[Redotheweb.com](http://redotheweb.com/2013/09/12/should-you-commit-dependencies.html)
