### PR TITLE
feat(Grunt) use 'load-grunt-tasks' to easier maintain dependencies

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,21 +3,9 @@ module.exports = function ( grunt ) {
   /** 
    * Load required Grunt tasks. These are installed based on the versions listed
    * in `package.json` when you do `npm install` in this directory.
+   * Task 'load-grunt-tasks' loads all tasks from 'package.json' with 'grunt-*' prefix
    */
-  grunt.loadNpmTasks('grunt-contrib-clean');
-  grunt.loadNpmTasks('grunt-contrib-copy');
-  grunt.loadNpmTasks('grunt-contrib-jshint');
-  grunt.loadNpmTasks('grunt-contrib-concat');
-  grunt.loadNpmTasks('grunt-contrib-watch');
-  grunt.loadNpmTasks('grunt-contrib-uglify');
-  grunt.loadNpmTasks('grunt-contrib-coffee');
-  grunt.loadNpmTasks('grunt-contrib-less');
-  grunt.loadNpmTasks('grunt-conventional-changelog');
-  grunt.loadNpmTasks('grunt-bump');
-  grunt.loadNpmTasks('grunt-coffeelint');
-  grunt.loadNpmTasks('grunt-karma');
-  grunt.loadNpmTasks('grunt-ngmin');
-  grunt.loadNpmTasks('grunt-html2js');
+  require('load-grunt-tasks')(grunt);
 
   /**
    * Load in our build configuration file.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "karma-jasmine": "^0.1.5",
     "grunt-karma": "^0.8.2",
     "karma-coffee-preprocessor": "^0.2.1",
-    "karma": "^0.12.9"
+    "karma": "^0.12.9",
+    "load-grunt-tasks": "^0.6.0"
   }
 }


### PR DESCRIPTION
Using 'load-grunt-tasks' to easier maintain dependencies in Gruntfile.js
