### PR TITLE
Automatically include livereload in build task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -374,7 +374,8 @@ module.exports = function ( grunt ) {
           '<%= html2js.app.dest %>',
           '<%= vendor_files.css %>',
           '<%= build_dir %>/assets/<%= pkg.name %>-<%= pkg.version %>.css'
-        ]
+        ],
+        lr: [ 'http://localhost:35729/livereload.js' ]
       },
 
       /**
@@ -388,7 +389,8 @@ module.exports = function ( grunt ) {
           '<%= concat.compile_js.dest %>',
           '<%= vendor_files.css %>',
           '<%= build_dir %>/assets/<%= pkg.name %>-<%= pkg.version %>.css'
-        ]
+        ],
+        lr: []  // we don't want to include livereload on compile
       }
     },
 
@@ -598,6 +600,7 @@ module.exports = function ( grunt ) {
     var cssFiles = filterForCSS( this.filesSrc ).map( function ( file ) {
       return file.replace( dirRE, '' );
     });
+    var lrFile = this.data.lr; // get the livereload file if it exists for this task
 
     grunt.file.copy('src/index.html', this.data.dir + '/index.html', { 
       process: function ( contents, path ) {
@@ -605,6 +608,7 @@ module.exports = function ( grunt ) {
           data: {
             scripts: jsFiles,
             styles: cssFiles,
+            lr: lrFile, // pass the livereload file
             version: grunt.config( 'pkg.version' )
           }
         });

--- a/src/index.html
+++ b/src/index.html
@@ -27,6 +27,9 @@
     <!-- compiled JavaScript --><% scripts.forEach( function ( file ) { %>
     <script type="text/javascript" src="<%= file %>"></script><% }); %>
 
+    <!-- liveReload if needed --><% lr.forEach( function ( file ) { %>
+    <script type="text/javascript" src="<%= file %>"></script><% }); %>
+
     <!-- it's stupid to have to load it here, but this is for the +1 button -->
     <script type="text/javascript" src="https://apis.google.com/js/plusone.js">
       { "parsetags": "explicit" }


### PR DESCRIPTION
Include livereload.js in the build task to remove need for extensions or
hardcoding. Fix for #284.
