### PR TITLE
Use correct Bootstrap name

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Happy hacking!
 with which to kickstart AngularJS projects. It contains a best-practice
 directory structure to ensure code reusability and maximum scalability.
 ngBoilerplate also comes prepackaged with the most popular design frameworks
-around: [Twitter Bootstrap](http://getbootstrap.com),
+around: [Bootstrap](http://getbootstrap.com),
 [Angular UI](http://angular-ui.github.io),
 [Angular Bootstrap](http://angular-ui.github.io/bootstrap),
 [Font Awesome](http://fortawesome.github.com/Font-Awesome), and


### PR DESCRIPTION
Bootstrap is no longer branded as "Twitter Bootstrap"
