### PR TITLE
Squashed commit of the following:

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -139,12 +139,28 @@ module.exports = function ( grunt ) {
           }
         ]
       },
+      build_vendorcss: {
+        files: [
+          {
+            src: [ '<%= vendor_files.css %>' ],
+            dest: '<%= build_dir %>/',
+            cwd: '.',
+            expand: true
+          }
+        ]
+      },
       compile_assets: {
         files: [
           {
             src: [ '**' ],
             dest: '<%= compile_dir %>/assets',
             cwd: '<%= build_dir %>/assets',
+            expand: true
+          },
+          {
+            src: [ '<%= vendor_files.css %>' ],
+            dest: '<%= compile_dir %>/',
+            cwd: '.',
             expand: true
           }
         ]
@@ -278,6 +294,8 @@ module.exports = function ( grunt ) {
         'Gruntfile.js'
       ],
       options: {
+        //smarttabs:true,
+        //laxcomma: true,
         curly: true,
         immed: true,
         newcap: true,
@@ -554,7 +572,7 @@ module.exports = function ( grunt ) {
   grunt.registerTask( 'build', [
     'clean', 'html2js', 'jshint', 'coffeelint', 'coffee', 'less:build',
     'concat:build_css', 'copy:build_app_assets', 'copy:build_vendor_assets',
-    'copy:build_appjs', 'copy:build_vendorjs', 'index:build', 'karmaconfig',
+    'copy:build_appjs', 'copy:build_vendorjs', 'copy:build_vendorcss', 'index:build', 'karmaconfig',
     'karma:continuous' 
   ]);
 


### PR DESCRIPTION
commit 46147e1889a25b190f16daade9df2be2e4eb4708
Author: Garris garris@me.com
Date:   Fri Aug 29 18:42:58 2014 -0700

```
added comments to jshint config

commented laxcomma & smarttabs options in jshint config
```

commit 2645c0e60112fcb4c666c747af1b4c11d9aa6501
Author: Garris garris@me.com
Date:   Fri Aug 29 18:34:31 2014 -0700

```
fixed vendor css compile issue

Added `build_vedndorcss` block and added block to copy vendor_files.css to bin on compile job.
```

commit 7f70c9cac39b89719a1fb1f1d32734e3d8801929
Author: Garris garris@me.com
Date:   Thu Aug 28 16:52:34 2014 -0700

```
fixed vendor CSS deploy issue

CSS files listed in /build.config.js > vendor_files.css are now correctly deployed to /build/vendor/[dirName...] as expected.
```
