### PR TITLE
ES6 support through SystemJS

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,6 @@
 module.exports = function ( grunt ) {
-  
-  /** 
+
+  /**
    * Load required Grunt tasks. These are installed based on the versions listed
    * in `package.json` when you do `npm install` in this directory.
    */
@@ -9,15 +9,10 @@ module.exports = function ( grunt ) {
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-contrib-watch');
-  grunt.loadNpmTasks('grunt-contrib-uglify');
-  grunt.loadNpmTasks('grunt-contrib-coffee');
   grunt.loadNpmTasks('grunt-contrib-less');
   grunt.loadNpmTasks('grunt-conventional-changelog');
   grunt.loadNpmTasks('grunt-bump');
-  grunt.loadNpmTasks('grunt-coffeelint');
   grunt.loadNpmTasks('grunt-karma');
-  grunt.loadNpmTasks('grunt-ngmin');
-  grunt.loadNpmTasks('grunt-html2js');
 
   /**
    * Load in our build configuration file.
@@ -25,7 +20,7 @@ module.exports = function ( grunt ) {
   var userConfig = require( './build.config.js' );
 
   /**
-   * This is the configuration object Grunt uses to give each plugin its 
+   * This is the configuration object Grunt uses to give each plugin its
    * instructions.
    */
   var taskConfig = {
@@ -36,12 +31,12 @@ module.exports = function ( grunt ) {
     pkg: grunt.file.readJSON("package.json"),
 
     /**
-     * The banner is the comment that is placed at the top of our compiled 
+     * The banner is the comment that is placed at the top of our compiled
      * source files. It is first processed as a Grunt template, where the `<%=`
      * pairs are evaluated based on this very configuration object.
      */
     meta: {
-      banner: 
+      banner:
         '/**\n' +
         ' * <%= pkg.name %> - v<%= pkg.version %> - <%= grunt.template.today("yyyy-mm-dd") %>\n' +
         ' * <%= pkg.homepage %>\n' +
@@ -67,13 +62,13 @@ module.exports = function ( grunt ) {
     bump: {
       options: {
         files: [
-          "package.json", 
+          "package.json",
           "bower.json"
         ],
         commit: false,
         commitMessage: 'chore(release): v%VERSION%',
         commitFiles: [
-          "package.json", 
+          "package.json",
           "client/bower.json"
         ],
         createTag: false,
@@ -82,13 +77,13 @@ module.exports = function ( grunt ) {
         push: false,
         pushTo: 'origin'
       }
-    },    
+    },
 
     /**
      * The directories to delete when `grunt clean` is executed.
      */
-    clean: [ 
-      '<%= build_dir %>', 
+    clean: [
+      '<%= build_dir %>',
       '<%= compile_dir %>'
     ],
 
@@ -100,29 +95,39 @@ module.exports = function ( grunt ) {
     copy: {
       build_app_assets: {
         files: [
-          { 
+          {
             src: [ '**' ],
             dest: '<%= build_dir %>/assets/',
             cwd: 'src/assets',
             expand: true
           }
-       ]   
+       ]
       },
       build_vendor_assets: {
         files: [
-          { 
+          {
             src: [ '<%= vendor_files.assets %>' ],
             dest: '<%= build_dir %>/assets/',
             cwd: '.',
             expand: true,
             flatten: true
           }
-       ]   
+       ]
       },
       build_appjs: {
         files: [
           {
             src: [ '<%= app_files.js %>' ],
+            dest: '<%= build_dir %>/',
+            cwd: '.',
+            expand: true
+          }
+        ]
+      },
+      build_apptpl: {
+        files: [
+          {
+            src: [ '<%= app_files.atpl %>', '<%= app_files.ctpl %>' ],
             dest: '<%= build_dir %>/',
             cwd: '.',
             expand: true
@@ -139,12 +144,32 @@ module.exports = function ( grunt ) {
           }
         ]
       },
+      build_systemjs: {
+        files: [
+          {
+            src: [ '<%= systemjs.loader_files %>', '<%= systemjs.config_file %>' ],
+            dest: '<%= build_dir %>/',
+            cwd: '.',
+            expand: true
+          }
+        ]
+      },
       compile_assets: {
         files: [
           {
             src: [ '**' ],
             dest: '<%= compile_dir %>/assets',
             cwd: '<%= build_dir %>/assets',
+            expand: true
+          }
+        ]
+      },
+      compile_vendorjs: {
+        files: [
+          {
+            src: [ '<%= systemjs.bundle_files %>' ],
+            dest: '<%= compile_dir %>/',
+            cwd: '.',
             expand: true
           }
         ]
@@ -165,75 +190,6 @@ module.exports = function ( grunt ) {
           '<%= build_dir %>/assets/<%= pkg.name %>-<%= pkg.version %>.css'
         ],
         dest: '<%= build_dir %>/assets/<%= pkg.name %>-<%= pkg.version %>.css'
-      },
-      /**
-       * The `compile_js` target is the concatenation of our application source
-       * code and all specified vendor source code into a single file.
-       */
-      compile_js: {
-        options: {
-          banner: '<%= meta.banner %>'
-        },
-        src: [ 
-          '<%= vendor_files.js %>', 
-          'module.prefix', 
-          '<%= build_dir %>/src/**/*.js', 
-          '<%= html2js.app.dest %>', 
-          '<%= html2js.common.dest %>', 
-          'module.suffix' 
-        ],
-        dest: '<%= compile_dir %>/assets/<%= pkg.name %>-<%= pkg.version %>.js'
-      }
-    },
-
-    /**
-     * `grunt coffee` compiles the CoffeeScript sources. To work well with the
-     * rest of the build, we have a separate compilation task for sources and
-     * specs so they can go to different places. For example, we need the
-     * sources to live with the rest of the copied JavaScript so we can include
-     * it in the final build, but we don't want to include our specs there.
-     */
-    coffee: {
-      source: {
-        options: {
-          bare: true
-        },
-        expand: true,
-        cwd: '.',
-        src: [ '<%= app_files.coffee %>' ],
-        dest: '<%= build_dir %>',
-        ext: '.js'
-      }
-    },
-
-    /**
-     * `ng-min` annotates the sources before minifying. That is, it allows us
-     * to code without the array syntax.
-     */
-    ngmin: {
-      compile: {
-        files: [
-          {
-            src: [ '<%= app_files.js %>' ],
-            cwd: '<%= build_dir %>',
-            dest: '<%= build_dir %>',
-            expand: true
-          }
-        ]
-      }
-    },
-
-    /**
-     * Minify the sources!
-     */
-    uglify: {
-      compile: {
-        options: {
-          banner: '<%= meta.banner %>'
-        },
-        files: {
-          '<%= concat.compile_js.dest %>': '<%= concat.compile_js.dest %>'
-        }
       }
     },
 
@@ -268,7 +224,7 @@ module.exports = function ( grunt ) {
      * nonetheless inside `src/`.
      */
     jshint: {
-      src: [ 
+      src: [
         '<%= app_files.js %>'
       ],
       test: [
@@ -284,57 +240,10 @@ module.exports = function ( grunt ) {
         noarg: true,
         sub: true,
         boss: true,
-        eqnull: true
+        eqnull: true,
+        esnext: true
       },
       globals: {}
-    },
-
-    /**
-     * `coffeelint` does the same as `jshint`, but for CoffeeScript.
-     * CoffeeScript is not the default in ngBoilerplate, so we're just using
-     * the defaults here.
-     */
-    coffeelint: {
-      src: {
-        files: {
-          src: [ '<%= app_files.coffee %>' ]
-        }
-      },
-      test: {
-        files: {
-          src: [ '<%= app_files.coffeeunit %>' ]
-        }
-      }
-    },
-
-    /**
-     * HTML2JS is a Grunt plugin that takes all of your template files and
-     * places them into JavaScript files as strings that are added to
-     * AngularJS's template cache. This means that the templates too become
-     * part of the initial payload as one JavaScript file. Neat!
-     */
-    html2js: {
-      /**
-       * These are the templates from `src/app`.
-       */
-      app: {
-        options: {
-          base: 'src/app'
-        },
-        src: [ '<%= app_files.atpl %>' ],
-        dest: '<%= build_dir %>/templates-app.js'
-      },
-
-      /**
-       * These are the templates from `src/common`.
-       */
-      common: {
-        options: {
-          base: 'src/common'
-        },
-        src: [ '<%= app_files.ctpl %>' ],
-        dest: '<%= build_dir %>/templates-common.js'
-      }
     },
 
     /**
@@ -368,13 +277,12 @@ module.exports = function ( grunt ) {
       build: {
         dir: '<%= build_dir %>',
         src: [
-          '<%= vendor_files.js %>',
-          '<%= build_dir %>/src/**/*.js',
-          '<%= html2js.common.dest %>',
-          '<%= html2js.app.dest %>',
+          '<%= systemjs.loader_files %>',
+          '<%= systemjs.config_file %>',
           '<%= vendor_files.css %>',
           '<%= build_dir %>/assets/<%= pkg.name %>-<%= pkg.version %>.css'
-        ]
+        ],
+        script: 'System.import(\'<%= systemjs.main_module %>\');'
       },
 
       /**
@@ -385,7 +293,8 @@ module.exports = function ( grunt ) {
       compile: {
         dir: '<%= compile_dir %>',
         src: [
-          '<%= concat.compile_js.dest %>',
+          '<%= systemjs.bundle_files %>',
+          '<%= bundle.app.dest %>',
           '<%= vendor_files.css %>',
           '<%= build_dir %>/assets/<%= pkg.name %>-<%= pkg.version %>.css'
         ]
@@ -399,10 +308,8 @@ module.exports = function ( grunt ) {
     karmaconfig: {
       unit: {
         dir: '<%= build_dir %>',
-        src: [ 
+        src: [
           '<%= vendor_files.js %>',
-          '<%= html2js.app.dest %>',
-          '<%= html2js.common.dest %>',
           '<%= test_files.js %>'
         ]
       }
@@ -410,13 +317,13 @@ module.exports = function ( grunt ) {
 
     /**
      * And for rapid development, we have a watch set up that checks to see if
-     * any of the files listed below change, and then to execute the listed 
+     * any of the files listed below change, and then to execute the listed
      * tasks when they do. This just saves us from having to type "grunt" into
      * the command-line every time we want to see what we're working on; we can
      * instead just leave "grunt watch" running in a background terminal. Set it
      * and forget it, as Ron Popeil used to tell us.
      *
-     * But we don't need the same thing to happen for all the files. 
+     * But we don't need the same thing to happen for all the files.
      */
     delta: {
       /**
@@ -446,21 +353,10 @@ module.exports = function ( grunt ) {
        * run our unit tests.
        */
       jssrc: {
-        files: [ 
+        files: [
           '<%= app_files.js %>'
         ],
         tasks: [ 'jshint:src', 'karma:unit:run', 'copy:build_appjs' ]
-      },
-
-      /**
-       * When our CoffeeScript source files change, we want to run lint them and
-       * run our unit tests.
-       */
-      coffeesrc: {
-        files: [ 
-          '<%= app_files.coffee %>'
-        ],
-        tasks: [ 'coffeelint:src', 'coffee:source', 'karma:unit:run', 'copy:build_appjs' ]
       },
 
       /**
@@ -468,7 +364,7 @@ module.exports = function ( grunt ) {
        * files, so this is probably not very useful.
        */
       assets: {
-        files: [ 
+        files: [
           'src/assets/**/*'
         ],
         tasks: [ 'copy:build_app_assets', 'copy:build_vendor_assets' ]
@@ -480,17 +376,6 @@ module.exports = function ( grunt ) {
       html: {
         files: [ '<%= app_files.html %>' ],
         tasks: [ 'index:build' ]
-      },
-
-      /**
-       * When our templates change, we only rewrite the template cache.
-       */
-      tpls: {
-        files: [ 
-          '<%= app_files.atpl %>', 
-          '<%= app_files.ctpl %>'
-        ],
-        tasks: [ 'html2js' ]
       },
 
       /**
@@ -513,20 +398,19 @@ module.exports = function ( grunt ) {
         options: {
           livereload: false
         }
-      },
+      }
+    },
 
-      /**
-       * When a CoffeeScript unit test file changes, we only want to lint it and
-       * run the unit tests. We don't want to do any live reloading.
-       */
-      coffeeunit: {
-        files: [
-          '<%= app_files.coffeeunit %>'
-        ],
-        tasks: [ 'coffeelint:test', 'karma:unit:run' ],
-        options: {
-          livereload: false
-        }
+    /**
+     * The `bundle` task compiles a single module and all it's dependencies, bundled
+     * into a single self-executing file.
+     */
+    bundle: {
+      app: {
+        configFile: '<%= systemjs.config_file %>',
+        moduleName: '<%= systemjs.main_module %>',
+        dest: '<%= compile_dir %>/assets/<%= pkg.name %>-<%= pkg.version %>.js',
+        bundleOptions: {minify: true, sourceMaps: true}
       }
     }
   };
@@ -552,10 +436,10 @@ module.exports = function ( grunt ) {
    * The `build` task gets your app ready to run for development and testing.
    */
   grunt.registerTask( 'build', [
-    'clean', 'html2js', 'jshint', 'coffeelint', 'coffee', 'less:build',
+    'clean', 'jshint', 'less:build',
     'concat:build_css', 'copy:build_app_assets', 'copy:build_vendor_assets',
-    'copy:build_appjs', 'copy:build_vendorjs', 'index:build', 'karmaconfig',
-    'karma:continuous' 
+    'copy:build_appjs', 'copy:build_apptpl', 'copy:build_vendorjs', 'copy:build_systemjs',
+    'index:build', 'karmaconfig', 'karma:continuous'
   ]);
 
   /**
@@ -563,7 +447,7 @@ module.exports = function ( grunt ) {
    * minifying your code.
    */
   grunt.registerTask( 'compile', [
-    'less:compile', 'copy:compile_assets', 'ngmin', 'concat:compile_js', 'uglify', 'index:compile'
+    'less:compile', 'copy:compile_vendorjs', 'copy:compile_assets', 'bundle:app', 'index:compile'
   ]);
 
   /**
@@ -584,7 +468,7 @@ module.exports = function ( grunt ) {
     });
   }
 
-  /** 
+  /**
    * The index.html template includes the stylesheet and javascript sources
    * based on dynamic names calculated in this Gruntfile. This task assembles
    * the list into variables for the template to use and then runs the
@@ -598,14 +482,16 @@ module.exports = function ( grunt ) {
     var cssFiles = filterForCSS( this.filesSrc ).map( function ( file ) {
       return file.replace( dirRE, '' );
     });
+    var scriptCode = this.data.script;
 
-    grunt.file.copy('src/index.html', this.data.dir + '/index.html', { 
+    grunt.file.copy('src/index.html', this.data.dir + '/index.html', {
       process: function ( contents, path ) {
         return grunt.template.process( contents, {
           data: {
             scripts: jsFiles,
             styles: cssFiles,
-            version: grunt.config( 'pkg.version' )
+            version: grunt.config( 'pkg.version' ),
+            scriptCode: scriptCode
           }
         });
       }
@@ -619,16 +505,44 @@ module.exports = function ( grunt ) {
    */
   grunt.registerMultiTask( 'karmaconfig', 'Process karma config templates', function () {
     var jsFiles = filterForJS( this.filesSrc );
-    
-    grunt.file.copy( 'karma/karma-unit.tpl.js', grunt.config( 'build_dir' ) + '/karma-unit.js', { 
+
+    grunt.file.copy( 'karma/karma-unit.tpl.js', grunt.config( 'build_dir' ) + '/karma-unit.js', {
       process: function ( contents, path ) {
         return grunt.template.process( contents, {
           data: {
-            scripts: jsFiles
+            scripts: jsFiles,
+            systemjs: {
+              config_file: grunt.config( 'systemjs.config_file' )
+            }
           }
         });
       }
     });
   });
 
+  grunt.registerMultiTask( 'bundle', 'Bundles a module and all it\'s dependencies', function() {
+    var builder = require('systemjs-builder'),
+      path = require('path');
+    var done = this.async();
+
+    var configFile = this.data.configFile;
+    var moduleName = this.data.moduleName;
+    var dest = this.data.dest;
+    var bundleOptions = this.data.bundleOptions;
+
+    // load SystemJS config from file
+    builder.loadConfig(configFile)
+      .then(function () {
+        // Change baseURL to match the file system
+        builder.config({baseURL: path.resolve('./')});
+
+        // Build a self-executing bundle (ie. Has SystemJS built in and auto-imports the 'app' module)
+        return builder.buildSFX(moduleName, dest, bundleOptions);
+      }).then(function() {
+        done();
+      }).catch(function (err) {
+        console.error(err);
+        done(err);
+      });
+  });
 };

--- a/README.md
+++ b/README.md
@@ -92,8 +92,6 @@ ng-boilerplate/
   |- bower.json
   |- build.config.js
   |- Gruntfile.js
-  |- module.prefix
-  |- module.suffix
   |- package.json
 ```
 
@@ -114,9 +112,6 @@ learn more.
 - `build.config.js` - our customizable build settings; see "The Build System"
   below.
 - `Gruntfile.js` - our build script; see "The Build System" below.
-- `module.prefix` and `module.suffix` - our compiled application script is
-  wrapped in these, which by default are used to place the application inside a
-  self-executing anonymous function to ensure no clashes with other libraries.
 - `package.json` - metadata about the app, used by NPM and our build script. Our
   NPM dependencies are listed here.
 
@@ -197,10 +192,9 @@ To ensure your setup works, launch grunt:
 $ grunt watch
 ```
 
-The built files are placed in the `build/` directory by default. Open the
-`build/index.html` file in your browser and check it out! Because everything is
-compiled, no XHR requests are needed to retrieve templates, so until this needs
-to communicate with your backend there is no need to run it from a web server.
+The built files are placed in the `build/` directory by default. You can view
+the application by starting a web server with `$ npm start` then opening
+[http://localhost:8000/build/index.html](http://localhost:8000/build/index.html)
 
 `watch` is actually an alias of the `grunt-contrib-watch` that will first run a
 partial build before watching for file changes. With this setup, any file that
@@ -221,12 +215,12 @@ command:
 $ grunt compile
 ```
 
-This will concatenate and minify your sources and place them by default into the
+This will bundle and minify your modules and place them by default into the
 `bin/` directory. There will only be three files: `index.html`,
-`your-app-name.js`, and `your-app-name.css`. All of the vendor dependencies like
-Bootstrap styles and AngularJS itself have been added to them for super-easy
-deploying. If you use any assets (`src/assets/`) then they will be copied to
-`bin/` as is.
+`your-app-name.js`, and `your-app-name.css`. All of the vendor dependencies
+(except traceur-runtime) like Bootstrap styles and AngularJS itself have been
+added to them for super-easy deploying. If you use any assets (`src/assets/`)
+then they will be copied to `bin/` as is.
 
 Lastly, a complete build is always available by simply running the default
 task, which runs `build` and then `compile`:
@@ -260,24 +254,8 @@ changes:
 * `delta:jssrc` - When any JavaScript file within `src/` that does not end in
   `.spec.js` changes, all JavaScript sources are linted, all unit tests are run,
   and the all source files are re-copied to `build/src`.
-* `delta:coffeesrc` - When any `*.coffee` file in `src/` that doesn't match
-  `*.spec.coffee` changes, the Coffee scripts are compiled independently into
-  `build/src` in a structure mirroring where they were in `src/` so it's easy to
-  locate problems. For example, the file
-  `src/common/titleService/titleService.coffee` is compiled to
-  `build/src/common/titleService/titleService.js`.
-* `delta:tpls` - When any `*.tpl.html` file within `src/` changes, all templates
-  are put into strings in a JavaScript file (technically two, one for
-  `src/common/` and another for `src/app/`) that will add the template to
-  AngularJS's
-  [`$templateCache`](http://docs.angularjs.org/api/ng.$templateCache) so
-  template files are part of the initial JavaScript payload and do not require
-  any future XHR.  The template cache files are `build/template-app.js` and
-  `build/template-common.js`.
 * `delta:jsunit` - When any `*.spec.js` file in `src/` changes, the test files
   are linted and the unit tests are executed.
-* `delta:coffeeunit` - When any `*.spec.coffee` file in `src/` changes, the test
-  files are linted, compiled their tests executed.
 
 As covered in the previous section, `grunt watch` will execute a full build
 up-front and then run any of the aforementioned `delta:*` tasks as needed to
@@ -297,7 +275,7 @@ compile. The build tasks (like those we've been discussing) are the minimal
 tasks required to run your app during development.
 
 Compile tasks, however, get your app ready for production. The compile tasks
-include concatenation, minification, compression, etc. These tasks take a little
+include bundling, minification, compression, etc. These tasks take a little
 bit longer to run and are not at all necessary for development so are not called
 automatically during build or watch.
 

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,8 @@
     "angular-mocks": "~1.2",
     "bootstrap": "~3.1",
     "angular-bootstrap": "~0.10.0",
-    "angular-ui-router": "~0.2"
+    "angular-ui-router": "~0.2",
+    "system.js": "~0.11.3"
   },
   "dependencies": {}
 }

--- a/build.config.js
+++ b/build.config.js
@@ -22,9 +22,6 @@ module.exports = {
   app_files: {
     js: [ 'src/**/*.js', '!src/**/*.spec.js', '!src/assets/**/*.js' ],
     jsunit: [ 'src/**/*.spec.js' ],
-    
-    coffee: [ 'src/**/*.coffee', '!src/**/*.spec.coffee' ],
-    coffeeunit: [ 'src/**/*.spec.coffee' ],
 
     atpl: [ 'src/app/**/*.tpl.html' ],
     ctpl: [ 'src/common/**/*.tpl.html' ],
@@ -63,14 +60,28 @@ module.exports = {
   vendor_files: {
     js: [
       'vendor/angular/angular.js',
-      'vendor/angular-bootstrap/ui-bootstrap-tpls.min.js',
+      'vendor/angular-bootstrap/ui-bootstrap-tpls.js',
       'vendor/placeholders/angular-placeholders-0.0.1-SNAPSHOT.min.js',
       'vendor/angular-ui-router/release/angular-ui-router.js',
-      'vendor/angular-ui-utils/modules/route/route.js'
+      'vendor/angular-ui-utils/modules/route/route.js',
+      'vendor/systemjs-plugin-text/text.js'
     ],
     css: [
     ],
     assets: [
     ]
   },
+
+  systemjs: {
+    loader_files: [
+      'vendor/traceur/traceur.js',
+      'vendor/es6-module-loader/dist/es6-module-loader.src.js',
+      'vendor/system.js/dist/system.src.js'
+    ],
+    bundle_files: [
+      'vendor/traceur-runtime/traceur-runtime.min.*'
+    ],
+    config_file: 'src/system.config.js',
+    main_module: 'src/app/app'
+  }
 };

--- a/karma/karma-unit.tpl.js
+++ b/karma/karma-unit.tpl.js
@@ -1,27 +1,29 @@
 module.exports = function ( karma ) {
   karma.set({
-    /** 
+    /**
      * From where to look for files, starting with the location of this file.
      */
     basePath: '../',
 
-    /**
-     * This is the list of file patterns to load into the browser during testing.
-     */
-    files: [
-      <% scripts.forEach( function ( file ) { %>'<%= file %>',
-      <% }); %>
-      'src/**/*.js',
-      'src/**/*.coffee',
-    ],
-    exclude: [
-      'src/assets/**/*.js'
-    ],
-    frameworks: [ 'jasmine' ],
-    plugins: [ 'karma-jasmine', 'karma-firefox-launcher', 'karma-coffee-preprocessor' ],
-    preprocessors: {
-      '**/*.coffee': 'coffee',
+    systemjs: {
+      /**
+       * This is the list of file patterns to load into the browser during testing.
+       */
+      files: [
+        <% scripts.forEach( function ( file ) { %>'<%= file %>',
+        <% }); %>
+        'src/**/*.tpl.html',
+        'src/**/*.js'
+      ],
+      configFile: '<%= systemjs.config_file %>',
+      config: {
+        paths: {
+          'angular-mocks': 'vendor/angular-mocks/angular-mocks.js'
+        }
+      }
     },
+    frameworks: [ 'systemjs', 'jasmine' ],
+    plugins: [ 'karma-systemjs', 'karma-jasmine', 'karma-firefox-launcher' ],
 
     /**
      * How to report, by default.
@@ -36,7 +38,7 @@ module.exports = function ( karma ) {
     runnerPort: 9100,
     urlRoot: '/',
 
-    /** 
+    /**
      * Disable file watching by default.
      */
     autoWatch: false,

--- a/module.prefix
+++ b/module.prefix
@@ -1,1 +1,0 @@
-(function ( window, angular, undefined ) {

--- a/module.suffix
+++ b/module.suffix
@@ -1,1 +1,0 @@
-})( window, window.angular );

--- a/package.json
+++ b/package.json
@@ -18,20 +18,23 @@
     "grunt-contrib-less": "~0.11.0",
     "grunt-contrib-clean": "^0.4.1",
     "grunt-contrib-copy": "^0.4.1",
-    "grunt-contrib-jshint": "^0.4.3",
+    "grunt-contrib-jshint": "^0.11.0",
     "grunt-contrib-concat": "^0.3.0",
     "grunt-contrib-watch": "^0.4.4",
-    "grunt-contrib-uglify": "^0.2.7",
-    "grunt-ngmin": "0.0.2",
-    "grunt-html2js": "^0.1.9",
-    "grunt-contrib-coffee": "^0.7.0",
-    "grunt-coffeelint": "~0.0.10",
     "grunt-conventional-changelog": "^0.1.2",
     "grunt-bump": "0.0.6",
     "karma-firefox-launcher": "^0.1.3",
     "karma-jasmine": "^0.1.5",
     "grunt-karma": "^0.8.2",
-    "karma-coffee-preprocessor": "^0.2.1",
-    "karma": "^0.12.9"
+    "karma": "^0.12.9",
+    "karma-systemjs": "^0.1.2",
+    "es6-module-loader": "^0.11.2",
+    "systemjs": "^0.11.3",
+    "systemjs-builder": "^0.5.3",
+    "traceur": "0.0.81",
+    "http-server": "^0.7.4"
+  },
+  "scripts": {
+    "start": "http-server -a localhost -p 8000 -c-1"
   }
 }

--- a/src/README.md
+++ b/src/README.md
@@ -19,17 +19,19 @@ src/
   |  |- main.less
   |  |- variables.less
   |- index.html
+  |- system.config.js
 ```
 
 - `src/app/` - application-specific code, i.e. code not likely to be reused in
   another application. [Read more &raquo;](app/README.md)
-- `src/assets/` - static files like fonts and images. 
+- `src/assets/` - static files like fonts and images.
   [Read more &raquo;](assets/README.md)
 - `src/common/` - third-party libraries or components likely to be reused in
   another application. [Read more &raquo;](common/README.md)
 - `src/less/` - LESS CSS files. [Read more &raquo;](less/README.md)
 - `src/index.html` - this is the HTML document of the single-page application.
   See below.
+- `src/system.config.js` - SystemJS configuration for loading modules.
 
 See each directory for a detailed explanation.
 

--- a/src/app/README.md
+++ b/src/app/README.md
@@ -9,6 +9,7 @@ src/
   |  |- about/
   |  |- app.js
   |  |- app.spec.js
+  |  |- app.ctrl.js
 ```
 
 The `src/app` directory contains all code specific to this application. Apart
@@ -74,16 +75,30 @@ have been instantiated.
 ```
 
 And then we define our main application controller. This is a good place for logic
-not specific to the template or route, such as menu logic or page title wiring.
+not specific to the template or route, such as menu logic or page title wiring. It's
+imported from `app.ctrl.js` (see below).
 
 ```js
-.controller( 'AppCtrl', function AppCtrl ( $scope, $location ) {
-  $scope.$on('$stateChangeSuccess', function(event, toState, toParams, fromState, fromParams){
-    if ( angular.isDefined( toState.data.pageTitle ) ) {
-      $scope.pageTitle = toState.data.pageTitle + ' | ngBoilerplate' ;
-    }
-  });
-})
+.controller( 'AppCtrl', AppCtrl )
+```
+
+## `app.ctrl.js`
+
+This is an example of an ES6 class being used as an AngularJS controller, without
+directly referencing the `angular` object.
+
+```js
+class AppCtrl {
+  constructor($scope) {
+    $scope.$on('$stateChangeSuccess', (event, toState) => {
+      if (angular.isDefined(toState.data.pageTitle)) {
+        $scope.pageTitle = toState.data.pageTitle + ' | ngBoilerplate';
+      }
+    });
+  }
+}
+AppCtrl.$inject = ['$scope'];
+export default AppCtrl;
 ```
 
 ### Testing

--- a/src/app/about/about.ctrl.js
+++ b/src/app/about/about.ctrl.js
@@ -1,0 +1,12 @@
+export default class AboutCtrl {
+
+  constructor() {
+    // This is simple a demo for UI Boostrap.
+    this.dropdownDemoItems = [
+      "The first choice!",
+      "And another choice for you.",
+      "but wait! A third!"
+    ];
+  }
+
+}

--- a/src/app/about/about.js
+++ b/src/app/about/about.js
@@ -1,29 +1,29 @@
-angular.module( 'ngBoilerplate.about', [
+import 'angular';
+import 'angular-ui-router';
+import 'placeholders';
+import 'angular-ui-bootstrap';
+import AboutCtrl from './about.ctrl';
+import template from './about.tpl.html!text';
+
+export default angular.module( 'ngBoilerplate.about', [
   'ui.router',
   'placeholders',
   'ui.bootstrap'
 ])
 
-.config(function config( $stateProvider ) {
+.config([ '$stateProvider', function config( $stateProvider ) {
   $stateProvider.state( 'about', {
     url: '/about',
     views: {
       "main": {
-        controller: 'AboutCtrl',
-        templateUrl: 'about/about.tpl.html'
+        controller: 'AboutCtrl as aboutCtrl',
+        template: template
       }
     },
     data:{ pageTitle: 'What is It?' }
   });
-})
+}])
 
-.controller( 'AboutCtrl', function AboutCtrl( $scope ) {
-  // This is simple a demo for UI Boostrap.
-  $scope.dropdownDemoItems = [
-    "The first choice!",
-    "And another choice for you.",
-    "but wait! A third!"
-  ];
-})
+.controller( 'AboutCtrl', AboutCtrl )
 
 ;

--- a/src/app/about/about.tpl.html
+++ b/src/app/about/about.tpl.html
@@ -16,7 +16,7 @@
   <h2>Why?</h2>
 
   <p>
-    Because my team and I make web apps, and 
+    Because my team and I make web apps, and
     last year AngularJS became our client-side framework of choice. We start
     websites the same way every time: create a directory structure, copy and
     ever-so-slightly tweak some config files from an older project, and yada
@@ -40,7 +40,7 @@
     you're looking for an example of what a complete, non-trivial AngularJS app
     that does something real looks like, complete with a REST backend and
     authentication and authorization, then take a look at <code><a
-        href="https://github.com/angular-app/angular-app/">angular-app</a></code>, 
+        href="https://github.com/angular-app/angular-app/">angular-app</a></code>,
     which does just that, and does it well.
   </p>
 
@@ -57,7 +57,7 @@
   </p>
 
   <p>
-    The high-altitude view is that the base project includes 
+    The high-altitude view is that the base project includes
     <a href="http://getbootstrap.com">Twitter Bootstrap</a>
     styles to quickly produce slick-looking responsive web sites and apps. It also
     includes <a href="http://angular-ui.github.com/bootstrap">UI Bootstrap</a>,
@@ -77,7 +77,7 @@
     that already, then how did you get here? Well, no matter - just drink the
     Kool Aid. Do it. You know you want to.
   </p>
-  
+
   <h2>Twitter Bootstrap</h2>
 
   <p>
@@ -87,7 +87,7 @@
     The LESS files are available for you to import in your main stylesheet as
     needed - no excess, no waste. There is also a dedicated place to override
     variables and mixins to suit your specific needs, so updating to the latest
-    version of Bootstrap is as simple as: 
+    version of Bootstrap is as simple as:
   </p>
 
   <pre>$ cd vendor/twitter-bootstrap<br />$ git pull origin master</pre>
@@ -103,7 +103,7 @@
     library contains a set of native AngularJS directives that are endlessly
     extensible. You get the tabs, the tooltips, the accordions. You get your
     carousel, your modals, your pagination. And <i>more</i>.
-    How about a quick demo? 
+    How about a quick demo?
   </p>
 
   <ul>
@@ -112,7 +112,7 @@
         Click me!
       </a>
       <ul class="dropdown-menu">
-        <li ng-repeat="choice in dropdownDemoItems">
+        <li ng-repeat="choice in aboutCtrl.dropdownDemoItems">
           <a>{{choice}}</a>
         </li>
       </ul>
@@ -120,7 +120,7 @@
   </ul>
 
   <p>
-    Oh, and don't include jQuery;  
+    Oh, and don't include jQuery;
     you don't need it.
     This is better.
     Don't be one of those people. <sup>*</sup>
@@ -132,12 +132,12 @@
 
   <p>
     Font Awesome has earned its label. It's a set of open (!) icons that come
-    distributed as a font (!) for super-easy, lightweight use. Font Awesome 
+    distributed as a font (!) for super-easy, lightweight use. Font Awesome
     works really well with Twitter Bootstrap, and so fits right in here.
   </p>
 
   <p>
-    There is not a single image on this site. All of the little images and icons 
+    There is not a single image on this site. All of the little images and icons
     are drawn through Font Awesome! All it takes is a little class:
   </p>
 
@@ -167,10 +167,10 @@
   </div>
 
   <p>
-    Even more exciting, you can also create placeholder images, entirely 
+    Even more exciting, you can also create placeholder images, entirely
     client-side! For example, this:
   </p>
-  
+
   <pre>
 &lt;img ph-img="50x50" /&gt;
 &lt;img ph-img="50x50" class="img-polaroid" /&gt;

--- a/src/app/app.ctrl.js
+++ b/src/app/app.ctrl.js
@@ -1,0 +1,11 @@
+class AppCtrl {
+  constructor($scope) {
+    $scope.$on('$stateChangeSuccess', (event, toState) => {
+      if (angular.isDefined(toState.data.pageTitle)) {
+        $scope.pageTitle = toState.data.pageTitle + ' | ngBoilerplate';
+      }
+    });
+  }
+}
+AppCtrl.$inject = ['$scope'];
+export default AppCtrl;

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -1,25 +1,23 @@
-angular.module( 'ngBoilerplate', [
-  'templates-app',
-  'templates-common',
+import 'angular';
+import './home/home';
+import './about/about';
+import 'angular-ui-router';
+import AppCtrl from './app.ctrl';
+
+export default angular.module( 'ngBoilerplate', [
   'ngBoilerplate.home',
   'ngBoilerplate.about',
   'ui.router'
 ])
 
-.config( function myAppConfig ( $stateProvider, $urlRouterProvider ) {
+.config( [ '$stateProvider', '$urlRouterProvider', function myAppConfig ( $stateProvider, $urlRouterProvider ) {
   $urlRouterProvider.otherwise( '/home' );
-})
+}])
 
 .run( function run () {
 })
 
-.controller( 'AppCtrl', function AppCtrl ( $scope, $location ) {
-  $scope.$on('$stateChangeSuccess', function(event, toState, toParams, fromState, fromParams){
-    if ( angular.isDefined( toState.data.pageTitle ) ) {
-      $scope.pageTitle = toState.data.pageTitle + ' | ngBoilerplate' ;
-    }
-  });
-})
+.controller( 'AppCtrl', AppCtrl )
 
 ;
 

--- a/src/app/app.spec.js
+++ b/src/app/app.spec.js
@@ -1,8 +1,11 @@
+import './app';
+import 'angular-mocks';
+
 describe( 'AppCtrl', function() {
   describe( 'isCurrentUrl', function() {
     var AppCtrl, $location, $scope;
 
-    beforeEach( module( 'ngBoilerplate' ) );
+    beforeEach( angular.mock.module( 'ngBoilerplate' ) );
 
     beforeEach( inject( function( $controller, _$location_, $rootScope ) {
       $location = _$location_;

--- a/src/app/home/README.md
+++ b/src/app/home/README.md
@@ -28,6 +28,13 @@ submodules `note.create`, `note.delete`, `note.search`, etc.
 Regardless, so long as dependencies are managed correctly, the build process
 will automatically take take of the rest.
 
+The route template is included as an ES6 module, run through the text plugin
+for SystemJS, which exports the template as a string.
+
+```js
+import template from './home.tpl.html!text';
+```
+
 The dependencies block is also where component dependencies should be
 specified, as shown below.
 
@@ -56,7 +63,7 @@ title (see the app.js controller).
     views: {
       "main": {
         controller: 'HomeCtrl',
-        templateUrl: 'home/home.tpl.html'
+        template: template
       }
     },
     data:{ pageTitle: 'Home' }

--- a/src/app/home/home.js
+++ b/src/app/home/home.js
@@ -1,3 +1,8 @@
+import 'angular';
+import 'angular-ui-router';
+import '../../common/plusOne/plusOne';
+import template from './home.tpl.html!text';
+
 /**
  * Each section of the site has its own module. It probably also has
  * submodules, though this boilerplate is too simple to demonstrate it. Within
@@ -12,7 +17,7 @@
  * The dependencies block here is also where component dependencies should be
  * specified, as shown below.
  */
-angular.module( 'ngBoilerplate.home', [
+export default angular.module( 'ngBoilerplate.home', [
   'ui.router',
   'plusOne'
 ])
@@ -22,24 +27,24 @@ angular.module( 'ngBoilerplate.home', [
  * will handle ensuring they are all available at run-time, but splitting it
  * this way makes each module more "self-contained".
  */
-.config(function config( $stateProvider ) {
+.config(['$stateProvider', function config( $stateProvider ) {
   $stateProvider.state( 'home', {
     url: '/home',
     views: {
       "main": {
         controller: 'HomeCtrl',
-        templateUrl: 'home/home.tpl.html'
+        template: template
       }
     },
     data:{ pageTitle: 'Home' }
   });
-})
+}])
 
 /**
  * And of course we define a controller for our route.
  */
-.controller( 'HomeCtrl', function HomeController( $scope ) {
-})
+.controller( 'HomeCtrl', [ '$scope', function HomeController( $scope ) {
+}])
 
 ;
 

--- a/src/app/home/home.spec.js
+++ b/src/app/home/home.spec.js
@@ -4,8 +4,12 @@
  * build process will exclude all `.spec.js` files from the build
  * automatically.
  */
+
+import './home';
+import 'angular-mocks';
+
 describe( 'home section', function() {
-  beforeEach( module( 'ngBoilerplate.home' ) );
+  beforeEach( angular.mock.module( 'ngBoilerplate.home' ) );
 
   it( 'should have a dummy test', inject( function() {
     expect( true ).toBeTruthy();

--- a/src/common/README.md
+++ b/src/common/README.md
@@ -7,8 +7,7 @@ specific to this application.
 Each component resides in its own directory that may then be structured any way
 the developer desires. The build system will read all `*.js` files that do not
 end in `.spec.js` as source files to be included in the final build, all
-`*.spec.js` files as unit tests to be executed, and all `*.tpl.html` files as
-templates to compiled into the `$templateCache`. There is currently no way to
+`*.spec.js` files as unit tests to be executed. There is currently no way to
 handle components that do not meet this pattern.
 
 ```
@@ -19,6 +18,6 @@ src/
 
 - `plusOne` - a simple directive to load a Google +1 Button on an element.
 
-Every component contained here should be drag-and-drop reusable in any other 
-project; they should depend on no other components that aren't similarly 
+Every component contained here should be drag-and-drop reusable in any other
+project; they should depend on no other components that aren't similarly
 drag-and-drop reusable.

--- a/src/common/plusOne/plusOne.js
+++ b/src/common/plusOne/plusOne.js
@@ -1,4 +1,6 @@
-angular.module( 'plusOne', [] )
+import 'angular';
+
+export default angular.module( 'plusOne', [] )
 
 .directive( 'plusOne', function() {
   return {

--- a/src/index.html
+++ b/src/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-<html ng-app="ngBoilerplate" ng-controller="AppCtrl">
+<html ng-app="ngBoilerplate" ng-controller="AppCtrl as appCtrl">
   <head>
-    <title ng-bind="pageTitle"></title>
+    <title ng-bind="appCtrl.pageTitle"></title>
 
     <!-- social media tags -->
     <meta name="twitter:card" content="summary">
@@ -27,6 +27,9 @@
     <!-- compiled JavaScript --><% scripts.forEach( function ( file ) { %>
     <script type="text/javascript" src="<%= file %>"></script><% }); %>
 
+    <% if ( scriptCode ) { %><!-- raw Javascript -->
+    <script type="text/javascript"><%= scriptCode %></script>
+    <% } %>
     <!-- it's stupid to have to load it here, but this is for the +1 button -->
     <script type="text/javascript" src="https://apis.google.com/js/plusone.js">
       { "parsetags": "explicit" }
@@ -100,19 +103,19 @@
             <li><a target="_blank" href="http://linkedin.com/in/joshdmiller"><i class="fa fa-linkedin-sign"></i></a></li>
             <li><a target="_blank" href="http://github.com/ngbp/ngbp"><i class="fa fa-github-sign"></i></a></li>
           </ul>
-          
+
 
           <p>
-            (c) 2013 <a href="http://www.joshdavidmiller.com">Josh David Miller</a>. 
+            (c) 2013 <a href="http://www.joshdavidmiller.com">Josh David Miller</a>.
             <a href="http://github.com/ngbp/ngbp/fork_select">Fork this</a>
             to kickstart your next project.
             <br />
             ngbp is based on
             <a href="http://www.angularjs.org">AngularJS</a>,
-            <a href="http://getbootstrap.com">Bootstrap</a>, 
+            <a href="http://getbootstrap.com">Bootstrap</a>,
             <a href="http://angular-ui.github.com/bootstrap">UI Bootstrap</a>,
-            and 
-            <a href="http://fortawesome.github.com/Font-Awesome">Font Awesome</a>.        
+            and
+            <a href="http://fortawesome.github.com/Font-Awesome">Font Awesome</a>.
           </p>
         </div>
       </div>

--- a/src/system.config.js
+++ b/src/system.config.js
@@ -1,0 +1,17 @@
+// Configure module loader
+System.config({
+  baseURL: './',
+
+  // Set paths for third-party libraries as modules
+  paths: {
+    'angular': 'vendor/angular/angular.js',
+    'angular-ui-router': 'vendor/angular-ui-router/release/angular-ui-router.js',
+    'angular-ui-bootstrap': 'vendor/angular-bootstrap/ui-bootstrap-tpls.js',
+    'placeholders': 'vendor/placeholders/angular-placeholders-0.0.1-SNAPSHOT.min.js'
+  },
+
+  // SystemJS Plugins, referenced with "moduleName!pluginName"
+  map: {
+    'text': 'vendor/systemjs-plugin-text/text'
+  }
+});

--- a/tools.md
+++ b/tools.md
@@ -52,7 +52,7 @@ where the magic happens.
 [Grunt](http://gruntjs.com) is a JavaScript task runner that runs on top of
 Node.js. Most importantly, Grunt brings us automation. There are lots of steps
 that go into taking our manageable codebase and making it into a
-production-ready website; we must gather, lint, test, annotate, and copy files
+production-ready website; we must gather, lint, test, and copy files
 about. Instead of doing all of that manually, we write (and use others') Grunt
 tasks to do things for us.
 
@@ -128,12 +128,9 @@ installed from NPM and configured as above:
 
 ```sh
 $ grunt clean
-$ grunt html2js
 $ grunt jshint
 $ grunt karma:continuous
 $ grunt concat
-$ grunt ngmin:dist
-$ grunt uglify
 $ grunt recess
 $ grunt index
 $ grunt copy

--- a/vendor/systemjs-plugin-text/text.js
+++ b/vendor/systemjs-plugin-text/text.js
@@ -1,0 +1,15 @@
+/*
+ Text plugin
+ */
+exports.translate = function(load) {
+  return 'module.exports = "' + load.source
+      .replace(/(["\\])/g, '\\$1')
+      .replace(/[\f]/g, "\\f")
+      .replace(/[\b]/g, "\\b")
+      .replace(/[\n]/g, "\\n")
+      .replace(/[\t]/g, "\\t")
+      .replace(/[\r]/g, "\\r")
+      .replace(/[\u2028]/g, "\\u2028")
+      .replace(/[\u2029]/g, "\\u2029")
+    + '";';
+};


### PR DESCRIPTION
Refactored ngBoilerplate to use [SystemJS](https://github.com/systemjs/systemjs) to load code as ES6 modules.

Pros:
- ES6 support
- Support for multiple module formats (eg. ES6, CommonJS, and AMD)
- Minification and concatenation of JS code handled by [systemjs-builder](https://github.com/systemjs/builder)
- Sourcemaps for JS code
- html2js replaced with loading "*.html" files as modules that export strings through the [SystemJS text plugin](https://github.com/systemjs/plugin-text)

Cons:
- Had to drop ngmin support as it (or at least it's replacement, ng-annotate) does not ([yet](https://github.com/olov/ng-annotate/issues/64)) support parsing ES6 code
- Had to drop CoffeeScript support as the [SystemJS coffee plugin](https://github.com/forresto/plugin-coffee) does not ([yet](https://github.com/forresto/plugin-coffee/issues/2)) support bundling
- Viewing `build/index.html` does now require a web server, as modules are asynchronously loaded at runtime (`bin/index.html` can still be run without a web server).
