### PR TITLE
fix(build): copy glyphicons files from vendor

### DIFF
--- a/build.config.js
+++ b/build.config.js
@@ -71,6 +71,7 @@ module.exports = {
     css: [
     ],
     assets: [
+      'vendor/bootstrap/fonts/*'
     ]
   },
 };

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -8,4 +8,5 @@
  */
 
 @sansFontFamily: 'Roboto', sans-serif;
+@icon-font-path: './'; //Bootstrap Glyphicons
 


### PR DESCRIPTION
Fix for #278, added bootstrap Glyphicons to vendor_files.assets and adjusted bootstrap icon-fon-path var in variables.less
