### PR TITLE
negated angular-placeholders-0.0.1-SNAPSHOT.min.js from .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 bin/
 node_modules/
 vendor/
+!vendor/placeholders/angular-placeholders-0.0.1-SNAPSHOT.min.js


### PR DESCRIPTION
This is to address the placeholder issue when migrating this boilerplate into another project. I realize that file has been out there for a while now, this is just a band aide to keep people from getting this fun surprise. 

Reference #198, #120 and #322 

Maybe we could just get this included into the boilerplate until the root issue is resolved.
