### PR TITLE
re-concat CSS files when LESS files change

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -514,7 +514,7 @@ module.exports = function ( grunt ) {
        */
       less: {
         files: [ 'src/**/*.less' ],
-        tasks: [ 'less:build' ]
+        tasks: [ 'less:build', 'concat:build_css' ]
       },
 
       /**


### PR DESCRIPTION
I noticed that whenever I changed a LESS file during a grunt watch all of my vendor CSS changes would be lost until I ran grunt watch or build again.  I traced the problem to the LESS task of the delta task.  It was rebuilding the LESS files whenever the LESS files were changed but it wasn't concatenating them with the vendor files again.  Quick fix.
