### PR TITLE
feat(karma-coverage): Add karma-coverage for test coverage reports.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 bin/
 node_modules/
 vendor/
+coverage/

--- a/karma/karma-unit.tpl.js
+++ b/karma/karma-unit.tpl.js
@@ -18,15 +18,22 @@ module.exports = function ( karma ) {
       'src/assets/**/*.js'
     ],
     frameworks: [ 'jasmine' ],
-    plugins: [ 'karma-jasmine', 'karma-firefox-launcher', 'karma-coffee-preprocessor' ],
+    plugins: [ 'karma-jasmine', 'karma-firefox-launcher', 'karma-coffee-preprocessor', 'karma-coverage' ],
     preprocessors: {
       '**/*.coffee': 'coffee',
+      'src/**/*.js': 'coverage'
     },
 
     /**
      * How to report, by default.
      */
-    reporters: 'dots',
+    reporters: ['dots', 'coverage'],
+
+    // Configures karma-coverage
+    coverageReporter: {
+      type : 'html',
+      dir : 'coverage/'
+    },
 
     /**
      * On which port should the browser connect, on which port is the test runner

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "grunt-ng-annotate": "^0.8.0",
     "karma": "^0.12.9",
     "karma-coffee-preprocessor": "^0.2.1",
+    "karma-coverage": "^0.2.7",
     "karma-firefox-launcher": "^0.1.3",
     "karma-jasmine": "^0.1.5"
   }


### PR DESCRIPTION
Adds karma-coverage, which generates code coverage using istanbul. Coverage reports are generated on every run of karma and saved to `coverage/`. This folder is also ignored in the `.gitignore` file as best a practice.

This PR fixes #349, which includes essentially the same changes, but follows ngBoilerplate contribution guidelines.
