### PR TITLE
Ultimate Fix Proposal: Vendor CSS issue during build & compile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -47,7 +47,6 @@ module.exports = function ( grunt ) {
         ' * <%= pkg.homepage %>\n' +
         ' *\n' +
         ' * Copyright (c) <%= grunt.template.today("yyyy") %> <%= pkg.author %>\n' +
-        ' * Licensed <%= pkg.licenses.type %> <<%= pkg.licenses.url %>>\n' +
         ' */\n'
     },
 
@@ -156,12 +155,6 @@ module.exports = function ( grunt ) {
             dest: '<%= compile_dir %>/assets',
             cwd: '<%= build_dir %>/assets',
             expand: true
-          },
-          {
-            src: [ '<%= vendor_files.css %>' ],
-            dest: '<%= compile_dir %>/',
-            cwd: '.',
-            expand: true
           }
         ]
       }
@@ -172,15 +165,15 @@ module.exports = function ( grunt ) {
      */
     concat: {
       /**
-       * The `build_css` target concatenates compiled CSS and vendor CSS
+       * The `compile_css` target concatenates compiled CSS and vendor CSS
        * together.
        */
-      build_css: {
+      compile_css: {
         src: [
           '<%= vendor_files.css %>',
-          '<%= build_dir %>/assets/<%= pkg.name %>-<%= pkg.version %>.css'
+          '<%= compile_dir %>/assets/<%= pkg.name %>-<%= pkg.version %>.css'
         ],
-        dest: '<%= build_dir %>/assets/<%= pkg.name %>-<%= pkg.version %>.css'
+        dest: '<%= compile_dir %>/assets/<%= pkg.name %>-<%= pkg.version %>.css'
       },
       /**
        * The `compile_js` target is the concatenation of our application source
@@ -266,7 +259,7 @@ module.exports = function ( grunt ) {
       },
       compile: {
         files: {
-          '<%= build_dir %>/assets/<%= pkg.name %>-<%= pkg.version %>.css': '<%= app_files.less %>'
+          '<%= compile_dir %>/assets/<%= pkg.name %>-<%= pkg.version %>.css': '<%= app_files.less %>'
         },
         options: {
           cleancss: true,
@@ -402,8 +395,7 @@ module.exports = function ( grunt ) {
         dir: '<%= compile_dir %>',
         src: [
           '<%= concat.compile_js.dest %>',
-          '<%= vendor_files.css %>',
-          '<%= build_dir %>/assets/<%= pkg.name %>-<%= pkg.version %>.css'
+          '<%= compile_dir %>/assets/<%= pkg.name %>-<%= pkg.version %>.css'
         ]
       }
     },
@@ -569,7 +561,7 @@ module.exports = function ( grunt ) {
    */
   grunt.registerTask( 'build', [
     'clean', 'html2js', 'jshint', 'coffeelint', 'coffee', 'less:build',
-    'concat:build_css', 'copy:build_app_assets', 'copy:build_vendor_assets',
+    'copy:build_app_assets', 'copy:build_vendor_assets',
     'copy:build_appjs', 'copy:build_vendorjs', 'copy:build_vendorcss', 'index:build', 'karmaconfig',
     'karma:continuous' 
   ]);
@@ -579,7 +571,7 @@ module.exports = function ( grunt ) {
    * minifying your code.
    */
   grunt.registerTask( 'compile', [
-    'less:compile', 'copy:compile_assets', 'ngAnnotate', 'concat:compile_js', 'uglify', 'index:compile'
+    'copy:compile_assets', 'less:compile', 'concat:compile_css', 'ngAnnotate', 'concat:compile_js', 'uglify', 'index:compile'
   ]);
 
   /**


### PR DESCRIPTION
I noticed that there are a bunch discussions about issues relevant to organizing vendor CSS via grunt build & compile tasks but all PRs as far as I can see did not get the point and makes the situation worse.

Thus I raised this PR. Should be able to solve issues mentioned in 
https://github.com/ngbp/ngbp/issues/340
https://github.com/ngbp/ngbp/pull/305
https://github.com/ngbp/ngbp/commit/67739b8bd9d9a19bdae6f830da3e134d89ab2735

My PR is implemented based on discussion in https://github.com/ngbp/ngbp/pull/185

As far as I know the correct way of loading external Vendor CSS is that
we define it in build.config.js->vender_files->css (other than
explicitly import it in main.less, etc); however there is something
wrong with loading vendor css via grunt tasks in commit
268901b9ee08103dd1e9ff2a136b1e46ccb78332.

Weird Behavior before this fix:
- vendor CSS will be concatenated(merged) instead of copied in build
- index.html still has reference to vendor CSS as standalone files in
  build
- vendor CSS will disappear if compile without build first because
  'copy:compile_assets' task simply copies concatenated all-in-one css
  file from build folder

Current Behavior after this fix:
- build no longer concatenates the vendor CSS while it now has correct,
  standalone reference in index.html to vendor CSS copied to its vendor
  folder
- compile has always vendor CSS concatenated (merged) and integrated
  regardless of whether build task has been performed

The modification has been tested under following cases:
- watch (delta)
- default (build & compile)
- compile after build
- compare w/o build

Still, please kindly notice:
- watch on LESS change will not notify to concatenate vendor CSS because
  they are not relevant in build
  From personal point of view I would not support following PRs, which did not suffice to be merged in the main branch:
  https://github.com/ngbp/ngbp/pull/369
  https://github.com/ngbp/ngbp/pull/390
- Regardless of what's mentioned in the documentation, compile task
  still partially depends on build task for javascript files in src/ while
  all vendor files (incl. CSS, JS) can be compiled successfully all the
  time. This is due to historical reasons that 'ngAnnotate' and
  'concat:compile_js' loads file from build folder. As I'm quite unsure if
  there exists modification during the process of copying those relevant
  app js from original src to build, I just leave it remained as for now.
