### PR TITLE
Use http-server to start simple server

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "grunt-html2js": "^0.1.9",
     "grunt-karma": "^0.8.2",
     "grunt-ng-annotate": "^0.8.0",
+    "http-server": "^0.9.0",
     "karma": "^0.12.9",
     "karma-coffee-preprocessor": "^0.2.1",
     "karma-firefox-launcher": "^0.1.3",


### PR DESCRIPTION
Using http-server package from npm to start a simple server and serve static files instead of opening the index.html file ( from the build or bin directory ) in the browser.
1) For build, run following command in the command prompt.
   http-server build/
2) For bin or production ready directory, run the following
   http-server bin/
