### PR TITLE
Support Environment configuration using grunt-ng-constant

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,6 +17,7 @@ module.exports = function ( grunt ) {
   grunt.loadNpmTasks('grunt-coffeelint');
   grunt.loadNpmTasks('grunt-karma');
   grunt.loadNpmTasks('grunt-ng-annotate');
+  grunt.loadNpmTasks('grunt-ng-constant');
   grunt.loadNpmTasks('grunt-html2js');
 
   /**
@@ -408,6 +409,20 @@ module.exports = function ( grunt ) {
       }
     },
 
+    ngconstant: {
+      options: {
+        dest: 'build/src/app/environment.js',
+        name: 'ngBoilerplate.constants',
+        wrap: '<%= __ngModule %>'
+      },
+      dev: {
+        constants: 'src/app/config/env.dev.json'
+      },
+      production: {
+        constants: 'src/app/config/env.prod.json'
+      }
+    },
+
     /**
      * This task compiles the karma template so that changes to its file array
      * don't have to be managed manually.
@@ -419,7 +434,8 @@ module.exports = function ( grunt ) {
           '<%= vendor_files.js %>',
           '<%= html2js.app.dest %>',
           '<%= html2js.common.dest %>',
-          '<%= test_files.js %>'
+          '<%= test_files.js %>',
+          '<%= ngconstant.options.dest %>'
         ]
       }
     },
@@ -568,7 +584,7 @@ module.exports = function ( grunt ) {
    * The `build` task gets your app ready to run for development and testing.
    */
   grunt.registerTask( 'build', [
-    'clean', 'html2js', 'jshint', 'coffeelint', 'coffee', 'less:build',
+    'clean', 'ngconstant:dev', 'html2js', 'jshint', 'coffeelint', 'coffee', 'less:build',
     'concat:build_css', 'copy:build_app_assets', 'copy:build_vendor_assets',
     'copy:build_appjs', 'copy:build_vendorjs', 'copy:build_vendorcss', 'index:build', 'karmaconfig',
     'karma:continuous' 
@@ -579,7 +595,7 @@ module.exports = function ( grunt ) {
    * minifying your code.
    */
   grunt.registerTask( 'compile', [
-    'less:compile', 'copy:compile_assets', 'ngAnnotate', 'concat:compile_js', 'uglify', 'index:compile'
+    'ngconstant:production', 'less:compile', 'copy:compile_assets', 'ngAnnotate', 'concat:compile_js', 'uglify', 'index:compile'
   ]);
 
   /**

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "grunt-html2js": "^0.1.9",
     "grunt-karma": "^0.8.2",
     "grunt-ng-annotate": "^0.8.0",
+    "grunt-ng-constant": "^2.0.1",
     "karma": "^0.12.9",
     "karma-coffee-preprocessor": "^0.2.1",
     "karma-firefox-launcher": "^0.1.3",

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -1,6 +1,7 @@
 angular.module( 'ngBoilerplate', [
   'templates-app',
   'templates-common',
+  'ngBoilerplate.constants',
   'ngBoilerplate.home',
   'ngBoilerplate.about',
   'ui.router'

--- a/src/app/app.spec.js
+++ b/src/app/app.spec.js
@@ -10,8 +10,9 @@ describe( 'AppCtrl', function() {
       AppCtrl = $controller( 'AppCtrl', { $location: $location, $scope: $scope });
     }));
 
-    it( 'should pass a dummy test', inject( function() {
+    it( 'should pass a dummy test', inject( function(ENV) {
       expect( AppCtrl ).toBeTruthy();
+      expect(ENV).toBeDefined();
     }));
   });
 });

--- a/src/app/config/env.dev.json
+++ b/src/app/config/env.dev.json
@@ -1,0 +1,6 @@
+{
+	"ENV" : {
+    	"name" : "Testing Environment",
+    	"APIEndpoint" : "http://dev:port/app/api/"
+    }
+}

--- a/src/app/config/env.prod.json
+++ b/src/app/config/env.prod.json
@@ -1,0 +1,6 @@
+{
+    "ENV" : {
+        "name" : "Production Environment",
+        "APIEndpoint" : "http://production:port/app/api/"
+    }
+}


### PR DESCRIPTION
If you are developing your application with multiple environments such as development, UAT and production you probably have a configuration file to handle things like API servers, constants. I am using grunt-ng-constant to do that. Different environment will have different .json configuration file. 
