### PR TITLE
fix(bower): Bower CLI installation prints progress as JSON output

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,5 +1,4 @@
 {
-  "directory": "vendor",
-  "json": "bower.json"
+  "directory": "vendor"
 }
 


### PR DESCRIPTION
Bower v1.7.8 and up prints installation output as json to console. Removing json property in .bowerrc fixed this. Related bower [issue](https://github.com/bower/bower/issues/2245).
